### PR TITLE
Use host camera position for joining users.

### DIFF
--- a/src/main/ogres/app/session.cljs
+++ b/src/main/ogres/app/session.cljs
@@ -117,6 +117,8 @@
              [:db/add -1 :local/cameras -2]
              [:db/add -2 :db/key (ds/squuid)]
              [:db/add -2 :camera/scene -3]
+             [:db/add -2 :camera/point (-> local :local/camera :camera/point)]
+             [:db/add -2 :camera/scale (-> local :local/camera :camera/scale)]
              [:db/add -3 :db/key (-> local :local/camera :camera/scene :db/key)]]
             [])
           report (ds/transact! conn (into tx-data tx-data-addtl))]

--- a/src/main/ogres/app/session.cljs
+++ b/src/main/ogres/app/session.cljs
@@ -117,8 +117,8 @@
              [:db/add -1 :local/cameras -2]
              [:db/add -2 :db/key (ds/squuid)]
              [:db/add -2 :camera/scene -3]
-             [:db/add -2 :camera/point (-> local :local/camera :camera/point)]
-             [:db/add -2 :camera/scale (-> local :local/camera :camera/scale)]
+             [:db/add -2 :camera/point (or (-> local :local/camera :camera/point) [0 0])]
+             [:db/add -2 :camera/scale (or (-> local :local/camera :camera/scale) 1)]
              [:db/add -3 :db/key (-> local :local/camera :camera/scene :db/key)]]
             [])
           report (ds/transact! conn (into tx-data tx-data-addtl))]


### PR DESCRIPTION
Fixes #73

This fix is incomplete and only syncs the top-left camera position, which may result in inconsistent views between host and users.

A proper fix would require waiting for user screen bounds to be transacted. Then the user's camera could be focused on the center point of the host's camera.