### PR TITLE
Improve keyboard accessibility for scene elements and more.

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -1,4 +1,5 @@
 {:extra-indents
  {use-subscribe      [[:inner 0]]
   use-event-listener [[:inner 0]]
+  use-shortcut       [[:inner 0]]
   $                  [[:inner 0]]}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@dnd-kit/core": "^6.0.8",
+        "@rwh/keystrokes": "^1.5.4",
+        "@rwh/react-keystrokes": "^1.5.4",
         "dexie": "^3.0.3",
         "dexie-export-import": "^4.1.1",
         "react": "^18.2.0",
@@ -65,6 +67,26 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@rwh/keystrokes": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@rwh/keystrokes/-/keystrokes-1.5.4.tgz",
+      "integrity": "sha512-8tf0EpqVRvyrKmDKNPEFV6lkXNjlWXM6aImZpygHzXStYslbBcpT9rKm4wiRadu8L6i4kHevBF+IamC6ouTJfQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/RobertWHurst"
+      }
+    },
+    "node_modules/@rwh/react-keystrokes": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@rwh/react-keystrokes/-/react-keystrokes-1.5.4.tgz",
+      "integrity": "sha512-F8T1GvPUKrxC8iLhb6+Wo7+z7QxM5FUKVRAFCmqYo8j67iy0wCg+fLTJS8DpKslznVYoRW7YTqfzDxta7OKWOg==",
+      "funding": {
+        "url": "https://github.com/sponsors/RobertWHurst"
+      },
+      "peerDependencies": {
+        "@rwh/keystrokes": "1.5.4",
+        "react": ">=17"
       }
     },
     "node_modules/asn1.js": {
@@ -1165,6 +1187,17 @@
       "requires": {
         "tslib": "^2.0.0"
       }
+    },
+    "@rwh/keystrokes": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@rwh/keystrokes/-/keystrokes-1.5.4.tgz",
+      "integrity": "sha512-8tf0EpqVRvyrKmDKNPEFV6lkXNjlWXM6aImZpygHzXStYslbBcpT9rKm4wiRadu8L6i4kHevBF+IamC6ouTJfQ=="
+    },
+    "@rwh/react-keystrokes": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@rwh/react-keystrokes/-/react-keystrokes-1.5.4.tgz",
+      "integrity": "sha512-F8T1GvPUKrxC8iLhb6+Wo7+z7QxM5FUKVRAFCmqYo8j67iy0wCg+fLTJS8DpKslznVYoRW7YTqfzDxta7OKWOg==",
+      "requires": {}
     },
     "asn1.js": {
       "version": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.0.8",
+    "@rwh/keystrokes": "^1.5.4",
+    "@rwh/react-keystrokes": "^1.5.4",
     "dexie": "^3.0.3",
     "dexie-export-import": "^4.1.1",
     "react": "^18.2.0",

--- a/src/main/ogres/app/hooks.cljs
+++ b/src/main/ogres/app/hooks.cljs
@@ -5,7 +5,8 @@
             [ogres.app.provider.portal   :as provider.portal]
             [ogres.app.provider.state    :as provider.state]
             [ogres.app.provider.storage  :as provider.storage]
-            [uix.core                    :refer [use-effect use-state use-ref use-callback]]))
+            [uix.core                    :refer [use-effect use-state use-ref use-callback]]
+            ["@rwh/keystrokes"           :refer [bindKey unbindKey]]))
 
 (def ^{:doc "Returns a function which, when called with a topic and any number
              of additional arguments, will perform the following work:
@@ -108,3 +109,11 @@
            (if (not (.contains node (.-target event)))
              (set-state false)))) []))
     [state set-state ref]))
+
+(defn use-shortcut
+  "Binds one or more keyboard codes to the callback function given by f which
+   receives a custom event as its only argument."
+  [keys f]
+  (use-effect
+   (fn [] (doseq [key keys] (bindKey key f))
+     (fn [] (doseq [key keys] (unbindKey key f)))) [keys f]))

--- a/src/main/ogres/app/provider/storage.cljs
+++ b/src/main/ogres/app/provider/storage.cljs
@@ -19,7 +19,6 @@
     :local/status
     :local/privileged?
     :local/sharing?
-    :local/modifier
     :session/state})
 
 (defn initialize []

--- a/src/main/ogres/app/render/scene.cljs
+++ b/src/main/ogres/app/render/scene.cljs
@@ -536,7 +536,6 @@
             ($ :pattern
               {:id (str "token-face-" checksum)
                :ref node
-               :style {:color "white"}
                :width "100%"
                :height "100%"
                :patternContentUnits "objectBoundingBox"}

--- a/src/main/ogres/app/render/scene.cljs
+++ b/src/main/ogres/app/render/scene.cljs
@@ -506,7 +506,7 @@
 
 (defui render-token-defs []
   (let [result (use-query query-token-defs)
-        {{{tokens :scene/tokens} :camera/scene} :local/camera} result]
+        tokens (-> result :local/camera :camera/scene :scene/tokens)]
     ($ :defs
       ($ :linearGradient {:id "token-base-player" :x1 0 :y1 0 :x2 1 :y2 1}
         ($ :stop {:style {:stop-color "#fcd34d"} :offset "0%"})

--- a/src/main/ogres/app/render/toolbar.cljs
+++ b/src/main/ogres/app/render/toolbar.cljs
@@ -80,6 +80,7 @@
         {:role "toolbar"
          :on-pointer-over on-focus
          :on-focus on-focus
+         :on-blur  #(set-focused nil)
          :on-click on-click}
         ($ action {:name "scene-select" :aria-pressed (= mode :select)}
           ($ icon {:name "cursor-fill"}))

--- a/src/main/ogres/app/shortcut.cljs
+++ b/src/main/ogres/app/shortcut.cljs
@@ -90,13 +90,15 @@
       (fn [data]
         (if (allowed? (.-originalEvent data))
           (let [[dx dy] (key->vector (.-key data))
-                attrs   (.. js/document -activeElement -dataset)]
+                attrs (.. js/document -activeElement -dataset)]
             (cond (.. data -originalEvent -altKey)
                   (dispatch :camera/translate (* dx 140) (* dy 140))
                   (= (.-type attrs) "scene")
                   (dispatch :camera/translate (* dx 140) (* dy 140))
                   (= (.-type attrs) "token")
-                  (dispatch :token/translate (js/Number (.-id attrs)) (* dx 70) (* dy 70)))))))
+                  (dispatch :token/translate (js/Number (.-id attrs)) (* dx 70) (* dy 70))
+                  (= (.-activeElement js/document) (.-body js/document))
+                  (dispatch :token/translate-selected (* dx 70) (* dy 70)))))))
 
     ;; Cut, copy, and paste tokens.
     (use-shortcut [\c \x \v]

--- a/web/release/ogres.app.css
+++ b/web/release/ogres.app.css
@@ -1029,14 +1029,21 @@ a:visited {
     }
   }
 
-  .scene-token-ring {
+  .scene-token-base {
     animation: ring-rotate 640ms linear infinite;
     fill: none;
     pointer-events: none;
     stroke-dasharray: 6px 2px;
     stroke-dashoffset: 0px;
-    stroke-width: var(--token-ring-stroke-width);
-    stroke: var(--token-ring-stroke);
+    stroke-width: var(--token-base-stroke-width);
+    stroke: var(--token-base-stroke);
+  }
+
+  .scene-token-ring {
+    fill: none;
+    pointer-events: none;
+    stroke-width: var(--token-outline-width, 0);
+    stroke: var(--color-prime-500);
   }
 
   .scene-token-aura {

--- a/web/release/ogres.app.css
+++ b/web/release/ogres.app.css
@@ -913,20 +913,30 @@ a:visited {
   &.scene-tokens-selected {
     --token-base-stroke: var(--color-session, var(--scene-stroke));
     --token-base-stroke-width: 1px;
+
+    .scene-token-position {
+      transition: none;
+
+      &[data-drag-remote="true"] {
+        transition: var(--transition-drag);
+      }
+    }
   }
 
   .scene-token-position {
     outline: none;
-
-    &:not([data-dragged-by="local"]) {
-      transition: var(--transition-drag);
-    }
+    transition: var(--transition-drag);
 
     &[data-hidden="true"] {
       display: none;
     }
 
-    &[data-dragging="true"] {
+    &[data-drag-local="true"] {
+      transition: none;
+    }
+
+    &[data-drag-local="true"],
+    &[data-drag-remote="true"] {
       --token-base-stroke: var(--color-session, var(--scene-stroke));
       --token-base-stroke-width: 2px;
     }

--- a/web/release/ogres.app.css
+++ b/web/release/ogres.app.css
@@ -477,7 +477,6 @@ a:visited {
       color: var(--color-black-400);
       cursor: pointer;
       display: flex;
-      outline: none;
 
       &:hover,
       &:focus-visible {
@@ -698,6 +697,13 @@ a:visited {
     --scene-text-outline: rgba(255, 255, 255, 1);
   }
 
+  &:has(.scene-handler:focus-visible) {
+    border-radius: 3px;
+    outline: 2px solid var(--outline-color);
+    position: relative;
+    z-index: 1;
+  }
+
   text,
   .scene-grid,
   .scene-image {
@@ -905,11 +911,13 @@ a:visited {
 /* Scene Tokens */
 .scene-tokens {
   &.scene-tokens-selected {
-    --token-ring-stroke: var(--color-session, var(--scene-stroke));
-    --token-ring-stroke-width: 1px;
+    --token-base-stroke: var(--color-session, var(--scene-stroke));
+    --token-base-stroke-width: 1px;
   }
 
   .scene-token-position {
+    outline: none;
+
     &:not([data-dragged-by="local"]) {
       transition: var(--transition-drag);
     }
@@ -919,8 +927,12 @@ a:visited {
     }
 
     &[data-dragging="true"] {
-      --token-ring-stroke: var(--color-session, var(--scene-stroke));
-      --token-ring-stroke-width: 2px;
+      --token-base-stroke: var(--color-session, var(--scene-stroke));
+      --token-base-stroke-width: 2px;
+    }
+
+    &:focus-visible {
+      --token-outline-width: 3px;
     }
   }
 


### PR DESCRIPTION
Resolves #121
Possibly resolves #12 

Scene
- [x] Use `Tab` to move focus to a token.
- [x] Use arrow keys to move a token that has focus.
- [x] Use arrow keys to move currently selected tokens.
- [x] Use `Spacebar` to select a focused token.
- [x] Use arrow keys to pan the camera when the scene has focus.
- [x] Use `Alt` + arrow keys to pan the camera around even if the scene does not have focus.
- [x] Use `Ctrl +` or `Ctrl -` to zoom the camera in and out.
- [x] Support Windows keyboard layouts for copy and paste.

Other
- [x] Use `Delete` or `Backspace` to delete the focused scene in the tab list.
- [ ] Use `Delete` or `Backspace` to delete the currently focused scene in the scene gallery.
- [ ] Use `Delete` or `Backspace` to delete the currently focused token in the token gallery.
- [ ] Support keyboard accessibility for the pagination component.

Issues
- [x] Tab index order can become inconsistent when the position of tokens change.
- [ ] Token movement is not always animated in some cases.