### PR TITLE
Add backup and restore functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.0.8",
         "dexie": "^3.0.3",
+        "dexie-export-import": "^4.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-transition-group": "^4.4.5"
@@ -368,6 +369,14 @@
       "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/dexie-export-import": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/dexie-export-import/-/dexie-export-import-4.1.1.tgz",
+      "integrity": "sha512-X6gm08h/HUM/b/iwAOtOTrtyz+maADKOUEODjfAMJDPQ31jwRGehRzycq0e67KL2Wh6xEaqeDmG00VFr2vIQNQ==",
+      "peerDependencies": {
+        "dexie": "^2.0.4 || ^3.0.0 || ^4.0.1-alpha.5"
       }
     },
     "node_modules/diffie-hellman": {
@@ -1442,6 +1451,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.2.tgz",
       "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg=="
+    },
+    "dexie-export-import": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/dexie-export-import/-/dexie-export-import-4.1.1.tgz",
+      "integrity": "sha512-X6gm08h/HUM/b/iwAOtOTrtyz+maADKOUEODjfAMJDPQ31jwRGehRzycq0e67KL2Wh6xEaqeDmG00VFr2vIQNQ==",
+      "requires": {}
     },
     "diffie-hellman": {
       "version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.0.8",
     "dexie": "^3.0.3",
+    "dexie-export-import": "^4.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-transition-group": "^4.4.5"

--- a/src/main/ogres/app/form/help.cljs
+++ b/src/main/ogres/app/form/help.cljs
@@ -12,10 +12,10 @@
   "Delete all your local data and restore this application to its original state?")
 
 (def ^:private confirm-backup
-  "Backup your local state and assets?")
+  "Backup your local data and images?")
 
 (def ^:private confirm-restore
-  "Delete all your local data and restore this application to the provided backup?")
+  "Delete all your local data and restore this application using the provided backup?")
 
 (defui form []
   (let [[file-name set-file-name] (use-state nil)

--- a/src/main/ogres/app/form/help.cljs
+++ b/src/main/ogres/app/form/help.cljs
@@ -3,7 +3,7 @@
             [ogres.app.hooks :refer [use-dispatch use-query]]
             [ogres.app.shortcut :refer [shortcuts]]
             [ogres.app.provider.release :as release]
-            [uix.core :refer [defui $ use-context]]))
+            [uix.core :refer [defui $ use-context use-ref use-state]]))
 
 (def ^:private confirm-upgrade
   "Upgrading will delete all your local data and restore this application to its original state.")
@@ -11,10 +11,18 @@
 (def ^:private confirm-delete
   "Delete all your local data and restore this application to its original state?")
 
+(def ^:private confirm-backup
+  "Backup your local state and assets?")
+
+(def ^:private confirm-restore
+  "Delete all your local data and restore this application to the provided backup?")
+
 (defui form []
-  (let [releases (use-context release/context)
-        dispatch (use-dispatch)
-        result   (use-query [[:local/type :default :conn]] [:db/ident :local])]
+  (let [[file-name set-file-name] (use-state nil)
+        releases  (use-context release/context)
+        dispatch  (use-dispatch)
+        result    (use-query [[:local/type :default :conn]] [:db/ident :local])
+        file-input (use-ref)]
     ($ :.form-help
       (if (= (:local/type result) :host)
         ($ :fieldset.fieldset
@@ -43,6 +51,57 @@
                      (fn []
                        (if-let [_ (js/confirm confirm-delete)]
                          (dispatch :storage/reset)))} "Delete local data")))))))
+      ($ :fieldset.fieldset
+        ($ :legend "Backup and Restore")
+        ($ :div.form-notice
+          ($ :<>
+            ($ :p "Backup and restore your current state and assets.")
+            ($ :br)
+            ($ :p "Restoring a backup will "
+              ($ :strong "delete all your current local data") ". ")
+            ($ :br)
+            ($ :button.button.button-neutral
+              {:on-click
+               (fn []
+                 (if-let [_ (js/confirm confirm-backup)]
+                   (dispatch :storage/backup)))} "Create Backup")
+            ($ :br)
+            ($ :form
+              {:class "form-restore"
+               :on-submit
+               (fn [event]
+                 (.preventDefault event)
+                 (let [files (.. file-input -current -files)
+                       file (first files)]
+                   (if-not (nil? file)
+                     (if-let [_ (js/confirm confirm-restore)]
+                       (dispatch :storage/restore file)))))}
+              ($ :div
+                {:style
+                 {:display "flex"
+                  :flex-flow "row rap"
+                  :gap "4px"}}
+                ($ :label
+                  {:for "restore-upload"
+                   :class "button button-neutral"
+                   :style {:box-sizing "border-box"}}
+                  (or file-name "Choose file"))
+                ($ :input
+                  {:type "file"
+                   :name "restore-upload"
+                   :id "restore-upload"
+                   :style {:display "none"}
+                   :accept ".blob"
+                   :ref file-input
+                   :on-change
+                   (fn [event]
+                     (let [files (.. event -target -files)
+                           file (first files)]
+                       (set-file-name (.-name file))))})
+                ($ :button.button.button-primary
+                  {:type "submit"
+                   :disabled (if (nil? file-name) true)}
+                  "Restore"))))))
       ($ :div
         ($ :h2 "Keyboard Shortcuts")
         ($ :table.shortcuts

--- a/src/main/ogres/app/form/help.cljs
+++ b/src/main/ogres/app/form/help.cljs
@@ -55,17 +55,19 @@
         ($ :legend "Backup and Restore")
         ($ :div.form-notice
           ($ :<>
-            ($ :p "Backup and restore your current state and assets.")
-            ($ :br)
-            ($ :p "Restoring a backup will "
-              ($ :strong "delete all your current local data") ". ")
-            ($ :br)
+            ($ :p {:style {:margin-bottom 4}}
+              "Create a backup file that contains all your data and images. You
+               can then use this file to restore your work on another computer
+               or browser.")
             ($ :button.button.button-neutral
               {:on-click
                (fn []
                  (if-let [_ (js/confirm confirm-backup)]
                    (dispatch :storage/backup)))} "Create Backup")
             ($ :br)
+            ($ :p {:style {:margin-bottom 4}}
+              "Select a backup file to restore your data and images. Note that "
+              ($ :strong "restoring from a file will delete all your current data") ".")
             ($ :form
               {:class "form-restore"
                :on-submit
@@ -91,7 +93,7 @@
                    :name "restore-upload"
                    :id "restore-upload"
                    :style {:display "none"}
-                   :accept ".blob"
+                   :accept ".json"
                    :ref file-input
                    :on-change
                    (fn [event]


### PR DESCRIPTION
Allows users to backup and restore the IndexedDB database via the `dexie-export-import` library.

When restoring, it will find the most recent app record within the database and load that version by replacing the current location with `/?r=VERSION`.

<img width="372" alt="A form with buttons to create and restore a backup." src="https://github.com/samcf/ogres/assets/1341869/37439957-4ebc-4156-97ed-5ac4cc546e27">