### PR TITLE
fix: have toolbar tooltip render absolutely to fix layout shifts

### DIFF
--- a/web/release/ogres.app.css
+++ b/web/release/ogres.app.css
@@ -523,7 +523,7 @@ a:visited {
     padding: 4px 8px;
     position: absolute;
     white-space: nowrap;
-    /* Subtract 2px both vertical borders and then 16px for the horizontal padding */
+    /* Subtract 2px to account for both vertical borders and then 16px for the horizontal padding */
     min-width: calc(100% - 18px);
     max-width: max-content;
     bottom: calc(100% + 4px);

--- a/web/release/ogres.app.css
+++ b/web/release/ogres.app.css
@@ -496,6 +496,7 @@ a:visited {
 /* Toolbar */
 .toolbar {
   pointer-events: all;
+  position: relative;
 
   &:has(:focus-visible) {
     border-radius: 2px;
@@ -519,8 +520,13 @@ a:visited {
     display: flex;
     font-size: 13px;
     gap: 8px;
-    margin-bottom: 4px;
     padding: 4px 8px;
+    position: absolute;
+    white-space: nowrap;
+    /* Subtract 2px both vertical borders and then 16px for the horizontal padding */
+    min-width: calc(100% - 18px);
+    max-width: max-content;
+    bottom: calc(100% + 4px);
   }
 
   .toolbar-shortcut {


### PR DESCRIPTION
Closes #125 

Solution I picked was to make tooltip render absolutely so as to not affect the toolbar. Takes a little math to correctly calculate offset and width, but tested on multiple screen sizes and should close out the issue!



https://github.com/samcf/ogres/assets/16494135/6a2b7166-48b0-4b9c-9b40-c242fc57a687

