### PR TITLE
Select and manipulate shapes and tokens together.

### DIFF
--- a/src/main/ogres/app/component/panel_initiative.cljs
+++ b/src/main/ogres/app/component/panel_initiative.cljs
@@ -145,7 +145,7 @@
          (fn [value]
            (dispatch :initiative/change-roll id value))})
       ($ :.initiative-token-frame
-        {:on-click #(dispatch :element/select id)
+        {:on-click #(dispatch :objects/select id)
          :data-player (contains? flags :player)
          :data-hidden hidden}
         (cond hidden \?

--- a/src/main/ogres/app/component/scene.cljs
+++ b/src/main/ogres/app/component/scene.cljs
@@ -622,6 +622,7 @@
                              :tab-index (if seen 0 -1)
                              :transform (str "translate(" tx ", " ty ")")
                              :on-pointer-down (or handler stop-propagation)
+                             :data-id id
                              :data-type (namespace (:object/type entity))}
                             ($ object {:entity entity}))))))))))))
       ($ use-portal {:name :selected}

--- a/src/main/ogres/app/component/scene.cljs
+++ b/src/main/ogres/app/component/scene.cljs
@@ -3,23 +3,19 @@
             [clojure.string :refer [join]]
             [goog.object :refer [getValueByKeys]]
             [ogres.app.component :refer [icon image]]
-            [ogres.app.component.scene-context-menu :refer [context-menu]]
             [ogres.app.component.scene-draw :refer [draw]]
+            [ogres.app.component.scene-objects :refer [objects]]
             [ogres.app.component.scene-pattern :refer [pattern]]
             [ogres.app.const :refer [grid-size]]
-            [ogres.app.geom :as geom]
             [ogres.app.hooks :refer [create-portal use-subscribe use-dispatch use-portal use-query]]
             [ogres.app.svg :refer [circle->path poly->path]]
-            [ogres.app.util :refer [key-by round]]
-            [react-transition-group :refer [TransitionGroup CSSTransition Transition]]
-            [uix.core :as uix :refer [defui $ create-ref use-callback use-effect use-memo use-state]]
-            [uix.dom :as dom]
+            [ogres.app.util :refer [key-by]]
+            [react-transition-group :refer [TransitionGroup Transition]]
+            [uix.core :as uix :refer [defui $ create-ref use-callback use-memo use-state]]
             ["@rwh/react-keystrokes" :refer [useKey] :rename {useKey use-key}]
             ["@dnd-kit/core"
-             :refer [DndContext useDndMonitor useDraggable]
-             :rename {DndContext dnd-context
-                      useDndMonitor use-dnd-monitor
-                      useDraggable use-draggable}]))
+             :refer [DndContext useDraggable]
+             :rename {DndContext dnd-context useDraggable use-draggable}]))
 
 (defn ^:private token-light-xf [user]
   (comp (filter (fn [{radius :token/light flags :token/flags}]
@@ -76,34 +72,6 @@
        #js {} (.-transform params)
        #js {"x" (/ dx scale)
             "y" (/ dy scale)}))))
-
-(defn ^:private use-cursor-point [uuid ox oy]
-  (let [[point set-point] (use-state nil)]
-    (use-effect
-     (fn []
-       (if (nil? uuid)
-         (set-point nil))) [uuid])
-    (use-subscribe :cursor/moved {:disabled (nil? uuid)}
-      (use-callback
-       (fn [{[id cx cy] :args}]
-         (if (= id uuid)
-           (set-point
-            (fn [[_ _ dx dy]]
-              (let [rx (- cx ox) ry (- cy oy)]
-                (if (nil? dx)
-                  [(- rx rx) (- ry ry) rx ry]
-                  [(- cx ox dx) (- cy oy dy) dx dy])))))) [uuid ox oy])) point))
-
-(defui ^:private drag-remote-fn
-  [{:keys [children user x y]}]
-  (let [point (use-cursor-point user x y)]
-    (children point)))
-
-(defui ^:private drag-local-fn
-  [{:keys [children id disabled]
-    :or   {disabled false}}]
-  (let [options (use-draggable #js {"id" id "disabled" (boolean disabled)})]
-    (children options)))
 
 (def ^:private image-defs-query
   [{:user/camera
@@ -296,44 +264,6 @@
       ($ :g {:id "scene-grid" :transform (str "translate(" (mod ox grid-size) "," (mod oy grid-size) ")")}
         ($ :path {:d (join " " ["M" ax ay "H" bx "V" by "H" ax "Z"]) :fill "url(#grid-pattern)"})))))
 
-(defui ^:private shape-circle
-  [{:keys [data]}]
-  (let [{[ax ay] :shape/points} data]
-    ($ :circle
-      {:cx 0 :cy 0 :r (geom/chebyshev-distance 0 0 ax ay)})))
-
-(defui ^:private shape-rect
-  [{:keys [data]}]
-  (let [{[ax ay] :shape/points} data]
-    ($ :path
-      {:d (join " " ["M" 0 0 "H" ax "V" ay "H" 0 "Z"])})))
-
-(defui ^:private shape-line
-  [{:keys [data]}]
-  (let [{[ax ay] :shape/points} data]
-    ($ :line
-      {:x1 0 :y1 0 :x2 ax :y2 ay :stroke-width 16 :stroke-linecap "round"})))
-
-(defui ^:private shape-cone
-  [{:keys [data]}]
-  (let [{[bx by] :shape/points} data]
-    ($ :polygon
-      {:points (join " " (geom/cone-points 0 0 bx by))})))
-
-(defui ^:private shape-poly
-  [{:keys [data]}]
-  (let [{points :shape/points} data]
-    ($ :polygon
-      {:points (join " " (into [0 0] points))})))
-
-(defui ^:private shape [props]
-  (case (keyword (name (:object/type (:data props))))
-    :circle ($ shape-circle props)
-    :rect   ($ shape-rect props)
-    :line   ($ shape-line props)
-    :cone   ($ shape-cone props)
-    :poly   ($ shape-poly props)))
-
 (defn ^:private token-flags [data]
   (let [{[{turn :initiative/turn}] :scene/_initiative} data]
     (cond-> (:token/flags data)
@@ -474,254 +404,6 @@
             ($ :g.scene-cursor
               {:transform (str "translate(" (- x 3) ", " (- y 3) ")") :data-color (:user/color conn)}
               ($ icon {:name "cursor-fill" :size 28}))))))))
-
-(def ^:private objects-query
-  [{:root/user
-    [:user/type
-     [:bounds/self :default [0 0 0 0]]
-     {:user/camera
-      [:db/id
-       :camera/selected
-       [:camera/scale :default 1]
-       [:camera/point :default [0 0]]
-       {:camera/scene
-        [[:scene/grid-origin :default [0 0]]
-         [:scene/grid-align :default false]
-         {:scene/tokens
-          [:db/id
-           [:object/type :default :token/token]
-           [:object/point :default [0 0]]
-           [:token/flags :default #{}]
-           [:token/label :default ""]
-           [:token/size :default 5]
-           [:token/light :default 15]
-           [:aura/radius :default 0]
-           {:token/image [:image/checksum]}
-           {:scene/_initiative [:db/id :initiative/turn]}]}
-         {:scene/shapes
-          [:db/id
-           [:object/type :default :shape/circle]
-           [:object/point :default [0 0]]
-           [:shape/points :default [0 0]]
-           [:shape/color :default "#f44336"]
-           [:shape/opacity :default 0.25]
-           [:shape/pattern :default :solid]]}]}]}]
-    :root/session
-    [{:session/conns
-      [:user/uuid :user/color :user/dragging]}]}])
-
-(defn ^:private object-tokens-xf [user]
-  (filter
-   (fn [token]
-     (or (= user :host)
-         (not (contains? (:token/flags token) :hidden))))))
-
-(defn ^:private object-tokens-cmp [a b]
-  (let [{size-a :token/size [ax ay] :object/point} a
-        {size-b :token/size [bx by] :object/point} b]
-    (compare [size-b ax ay] [size-a bx by])))
-
-(defn ^:private object-shapes-cmp [a b]
-  (let [{[ax ay] :object/point} a
-        {[bx by] :object/point} b]
-    (compare [ax ay] [bx by])))
-
-(defui ^:private object-token [props]
-  (let [{id :db/id} (:entity props)]
-    ($ :<>
-      ($ :use {:href (str "#token" id)})
-      (if-let [[ax ay bx by] (:aligned-to props)]
-        (if-let [portal (deref (:portal props))]
-          (dom/create-portal
-           ($ :g.scene-object-align
-             ($ :rect
-               {:x  ax :y (+ ay 1)
-                :rx 3  :ry 3
-                :width (- bx ax 1)
-                :height (- by ay 1)})) portal))))))
-
-(defui ^:private object-shape [{:keys [entity]}]
-  (let [{id :db/id
-         color :shape/color
-         pattern-name :shape/pattern
-         opacity :shape/opacity
-         [ax ay] :object/point} entity
-        [bx by cx cy] (geom/object-bounding-rect entity)]
-    ($ :g.scene-shape
-      ($ :defs.scene-shape-defs
-        ($ pattern
-          {:id (str "shape-pattern-" id)
-           :name pattern-name
-           :color color}))
-      ($ :rect.scene-shape-bounds
-        {:x (- bx ax 6)
-         :y (- by ay 6)
-         :rx 3
-         :ry 3
-         :width (+ (- cx bx) (* 6 2))
-         :height (+ (- cy by) (* 6 2))})
-      ($ :g.scene-shape-path {:stroke color :fill (str "url(#shape-pattern-" id ")") :fill-opacity opacity}
-        ($ shape {:data entity})))))
-
-(defui ^:private object [props]
-  (case (keyword (namespace (:object/type (:entity props))))
-    :token ($ object-token props)
-    :shape ($ object-shape props)))
-
-(defn ^:private use-objects-listener []
-  (let [dispatch (use-dispatch)]
-    (use-dnd-monitor
-     #js {"onDragStart"
-          (use-callback
-           (fn [data]
-             (let [id (.. data -active -id)]
-               (if (= id "selected")
-                 (dispatch :drag/start-selected)
-                 (dispatch :drag/start id)))) [dispatch])
-          "onDragCancel"
-          (use-callback
-           (fn []
-             (dispatch :drag/end)) [dispatch])
-          "onDragEnd"
-          (use-callback
-           (fn [data]
-             (let [event (.-activatorEvent data)
-                   id (.. data -active -id)
-                   dx (.. data -delta -x)
-                   dy (.. data -delta -y)
-                   sh (.-shiftKey event)]
-               (if (and (= dx 0) (= dy 0))
-                 (if (= id "selected")
-                   (let [id (.. event -target (closest "[data-id]") -dataset -id)]
-                     (dispatch :objects/select (js/Number id) sh))
-                   (dispatch :objects/select id sh))
-                 (if (= id "selected")
-                   (dispatch :objects/translate-selected dx dy)
-                   (dispatch :objects/translate id dx dy))))) [dispatch])})))
-
-(defn ^:private object-align-xf [dx dy ox oy]
-  (comp (partition-all 2)
-        (mapcat
-         (fn [[x y]]
-           [(+ (round (- (+ x dx) ox) grid-size) ox)
-            (+ (round (- (+ y dy) oy) grid-size) oy)]))))
-
-(defui ^:private objects []
-  (let [result (use-query objects-query [:db/ident :root])
-        {{[_ _ bw bh] :bounds/self
-          type :user/type
-          {[cx cy]  :camera/point
-           scale    :camera/scale
-           selected :camera/selected
-           {[ox oy] :scene/grid-origin
-            align? :scene/grid-align
-            tokens :scene/tokens
-            shapes :scene/shapes}
-           :camera/scene}
-          :user/camera} :root/user
-         {conns :session/conns} :root/session} result
-        portal (uix/use-ref)
-        bounds [cx cy (+ (/ bw scale) cx) (+ (/ bh scale) cy)]
-        shapes (sort object-shapes-cmp shapes)
-        tokens (sort object-tokens-cmp (sequence (object-tokens-xf type) tokens))
-        entities (concat shapes tokens)
-        selected (into #{} (map :db/id) selected)
-        selectxf (filter (comp selected :db/id))
-        drags-xf (comp (filter (comp seq :user/dragging))
-                       (mapcat (fn [user]
-                                 (map (juxt :db/id (constantly user))
-                                      (:user/dragging user)))))
-        dragging (into {} drags-xf conns)]
-    (use-objects-listener)
-    ($ :g.scene-objects {}
-      ($ :g.scene-objects-portal
-        {:ref portal :tab-index -1})
-      ($ TransitionGroup {:component nil}
-        (for [entity entities
-              :let [{id :db/id [ax ay] :object/point} entity
-                    node (create-ref)
-                    user (dragging id)
-                    rect (geom/object-bounding-rect entity)
-                    seen (geom/rect-intersects-rect rect bounds)]]
-          ($ CSSTransition {:key id :nodeRef node :timeout 256}
-            ($ :g.scene-object-transition {:ref node}
-              (if (not (selected id))
-                ($ drag-remote-fn {:user (:user/uuid user) :x ax :y ay}
-                  (fn [[rx ry]]
-                    ($ drag-local-fn {:id id :disabled (some? user)}
-                      (fn [drag]
-                        (let [handler (getValueByKeys drag "listeners" "onPointerDown")
-                              dx (or (getValueByKeys drag "transform" "x") 0)
-                              dy (or (getValueByKeys drag "transform" "y") 0)
-                              tx (+ ax (or rx dx 0))
-                              ty (+ ay (or ry dy 0))
-                              to (if (and align? (.-isDragging drag) (or (not= dx 0) (not= dy 0)))
-                                   (into [] (object-align-xf dx dy ox oy) rect))]
-                          ($ :g.scene-object
-                            {:ref (.-setNodeRef drag)
-                             :transform (str "translate(" tx ", " ty ")")
-                             :tab-index (if seen 0 -1)
-                             :on-pointer-down (or handler stop-propagation)
-                             :data-drag-remote (some? user)
-                             :data-drag-local (.-isDragging drag)
-                             :data-color (:user/color user)
-                             :data-type (namespace (:object/type entity))
-                             :data-id id}
-                            ($ object
-                              {:entity entity
-                               :portal portal
-                               :aligned-to to}))))))))))))
-      ($ use-portal {:name :selected}
-        (let [bounds (sequence (comp selectxf (mapcat geom/object-bounding-rect)) entities)
-              bounds (geom/bounding-rect bounds)
-              [ax ay bx by] bounds]
-          ($ drag-local-fn {:id "selected" :disabled (some dragging selected)}
-            (fn [drag]
-              (let [handler (getValueByKeys drag "listeners" "onPointerDown")
-                    dx (or (getValueByKeys drag "transform" "x") 0)
-                    dy (or (getValueByKeys drag "transform" "y") 0)]
-                ($ :g.scene-objects.scene-objects-selected
-                  {:ref (.-setNodeRef drag)
-                   :transform (str "translate(" dx ", " dy ")")
-                   :on-pointer-down (or handler stop-propagation)
-                   :data-drag-local (.-isDragging drag)}
-                  (if (> (count selected) 1)
-                    ($ :rect.scene-objects-bounds
-                      {:x (- ax 6) :y (- ay 6)
-                       :width  (+ (- bx ax) (* 6 2))
-                       :height (+ (- by ay) (* 6 2))
-                       :rx 3 :ry 3}))
-                  ($ TransitionGroup {:component nil}
-                    (for [entity entities
-                          :let [{id :db/id [ax ay] :object/point} entity
-                                node (create-ref)
-                                user (dragging id)
-                                rect (geom/object-bounding-rect entity)
-                                rect (if (and align? (.-isDragging drag) (or (not= dx 0) (not= dy 0)))
-                                       (into [] (object-align-xf dx dy ox oy) rect))]]
-                      ($ CSSTransition {:key id :nodeRef node :timeout 256}
-                        ($ :g.scene-object-transition {:ref node}
-                          (if (selected id)
-                            ($ drag-remote-fn {:user (:user/uuid user) :x ax :y ay}
-                              (fn [[rx ry]]
-                                ($ :g.scene-object
-                                  {:transform (str "translate(" (+ ax rx) ", " (+ ay ry) ")")
-                                   :data-drag-remote (some? user)
-                                   :data-drag-local (.-isDragging drag)
-                                   :data-color (:user/color user)
-                                   :data-type (namespace (:object/type entity))
-                                   :data-id id}
-                                  ($ object
-                                    {:entity entity
-                                     :portal portal
-                                     :aligned-to rect})))))))))
-                  (let [sz 400
-                        tx (-> (+ ax bx) (* scale) (- sz) (/ 2) int)
-                        ty (-> (+ by 24) (* scale) (- 24) int)
-                        tf (str "scale(" (/ scale) ")")]
-                    ($ :foreignObject.context-menu-object
-                      {:x tx :y ty :width sz :height sz :transform tf}
-                      ($ context-menu {:data (sequence selectxf entities) :type type}))))))))))))
 
 (defui ^:private scene-camera-draggable
   [{:keys [children]}]

--- a/src/main/ogres/app/component/scene.cljs
+++ b/src/main/ogres/app/component/scene.cljs
@@ -297,36 +297,33 @@
 
 (defui ^:private shape-circle
   [{:keys [data]}]
-  (let [{[ax ay bx by] :shape/points} data]
+  (let [{[ax ay] :shape/points} data]
     ($ :circle
-      {:cx 0 :cy 0 :r (geom/chebyshev-distance ax ay bx by)})))
+      {:cx 0 :cy 0 :r (geom/chebyshev-distance 0 0 ax ay)})))
 
 (defui ^:private shape-rect
   [{:keys [data]}]
-  (let [{[ax ay bx by] :shape/points} data]
+  (let [{[ax ay] :shape/points} data]
     ($ :path
-      {:d (join " " ["M" 0 0 "H" (- bx ax) "V" (- by ay) "H" 0 "Z"])})))
+      {:d (join " " ["M" 0 0 "H" ax "V" ay "H" 0 "Z"])})))
 
 (defui ^:private shape-line
   [{:keys [data]}]
-  (let [{[ax ay bx by] :shape/points} data]
+  (let [{[ax ay] :shape/points} data]
     ($ :line
-      {:x1 0 :y1 0 :x2 (- bx ax) :y2 (- by ay)})))
+      {:x1 0 :y1 0 :x2 ax :y2 ay})))
 
 (defui ^:private shape-cone
   [{:keys [data]}]
-  (let [{[ax ay bx by] :shape/points} data]
+  (let [{[bx by] :shape/points} data]
     ($ :polygon
-      {:points (join " " (geom/cone-points 0 0 (- bx ax) (- by ay)))})))
+      {:points (join " " (geom/cone-points 0 0 bx by))})))
 
 (defui ^:private shape-poly
   [{:keys [data]}]
-  (let [xf (fn [x y] (comp (partition-all 2) (mapcat (fn [[ax ay]] [(- ax x) (- ay y)]))))
-        {points :shape/points} data
-        [ax ay] (into [] (take 2) points)
-        pairs   (into [] (xf ax ay) points)]
+  (let [{points :shape/points} data]
     ($ :polygon
-      {:points (join " " pairs)})))
+      {:points (join " " (into [0 0] points))})))
 
 (defui ^:private shape [props]
   (case (keyword (name (:object/type (:data props))))

--- a/src/main/ogres/app/component/scene.cljs
+++ b/src/main/ogres/app/component/scene.cljs
@@ -311,7 +311,7 @@
   [{:keys [data]}]
   (let [{[ax ay] :shape/points} data]
     ($ :line
-      {:x1 0 :y1 0 :x2 ax :y2 ay})))
+      {:x1 0 :y1 0 :x2 ax :y2 ay :stroke-width 16 :stroke-linecap "round"})))
 
 (defui ^:private shape-cone
   [{:keys [data]}]

--- a/src/main/ogres/app/component/scene_context_menu.cljs
+++ b/src/main/ogres/app/component/scene_context_menu.cljs
@@ -265,7 +265,7 @@
            :auto-focus true
            :on-change
            (fn [event]
-             (on-change :object/update :shape/opacity (.. event -target -value)))})))
+             (on-change :objects/update :shape/opacity (.. event -target -value)))})))
     ($ :fieldset.fieldset
       ($ :legend "Color")
       ($ :.context-menu-form-colors
@@ -278,7 +278,7 @@
                :checked (= value (first (values :shape/color)))
                :on-change
                (fn [event]
-                 (on-change :object/update :shape/color (.. event -target -value)))})))))))
+                 (on-change :objects/update :shape/color (.. event -target -value)))})))))))
 
 (defui ^:private shape-form-pattern
   [{:keys [on-change values]}]
@@ -295,7 +295,7 @@
            :on-change
            (fn [event]
              (let [value (.. event -target -value)]
-               (on-change :object/update :shape/pattern (keyword value))))})
+               (on-change :objects/update :shape/pattern (keyword value))))})
         ($ :svg
           ($ :defs ($ pattern {:id id :name value}))
           ($ :rect {:x 0 :y 0 :width "100%" :height "100%" :fill (str "url(#" id ")")}))))))

--- a/src/main/ogres/app/component/scene_context_menu.cljs
+++ b/src/main/ogres/app/component/scene_context_menu.cljs
@@ -5,7 +5,7 @@
             [ogres.app.hooks :refer [use-dispatch]]
             [uix.core :as uix :refer [defui $ use-effect use-ref use-state]]))
 
-(defn token-size [x]
+(defn ^:private token-size [x]
   (cond (<= x 3)  "Tiny"
         (<  x 5)  "Small"
         (<= x 5)  "Medium"
@@ -54,7 +54,7 @@
 (defn ^:private stop-propagation [event]
   (.stopPropagation event))
 
-(defui ^:private context-menu
+(defui ^:private context-menu-fn
   [{:keys [render-toolbar render-aside children]
     :or   {render-toolbar (constantly nil)
            render-aside   (constantly nil)}}]
@@ -187,10 +187,10 @@
                    ((:on-change props) :token/change-flag value checked)))})
             ($ icon {:name icon-name})))))))
 
-(defui token-context-menu [{:keys [tokens type]}]
+(defui ^:private context-menu-token [{:keys [data type]}]
   (let [dispatch (use-dispatch)
-        idxs (map :db/id tokens)]
-    ($ context-menu
+        idxs (map :db/id data)]
+    ($ context-menu-fn
       {:render-toolbar
        (fn [{:keys [selected on-change]}]
          ($ :<>
@@ -205,21 +205,21 @@
                 :data-tooltip tooltip
                 :on-click #(on-change form)}
                ($ icon {:name icon-name})))
-           (let [on (every? (comp vector? :scene/_initiative) tokens)]
+           (let [on (every? (comp vector? :scene/_initiative) data)]
              ($ :button
                {:type "button"
                 :data-selected on
                 :data-tooltip "Initiative"
                 :on-click #(dispatch :initiative/toggle idxs (not on))}
                ($ icon {:name "hourglass-split"})))
-           (let [on (every? (comp boolean :player :token/flags) tokens)]
+           (let [on (every? (comp boolean :player :token/flags) data)]
              ($ :button
                {:type "button"
                 :data-tooltip "Player"
                 :data-selected on
                 :on-click #(dispatch :token/change-flag idxs :player (not on))}
                ($ icon {:name "people-fill"})))
-           (let [on (every? (comp boolean :dead :token/flags) tokens)]
+           (let [on (every? (comp boolean :dead :token/flags) data)]
              ($ :button
                {:type "button"
                 :data-tooltip "Dead"
@@ -230,7 +230,7 @@
        (fn []
          ($ :<>
            (if (= type :host)
-             (let [on (every? (comp boolean :hidden :token/flags) tokens)]
+             (let [on (every? (comp boolean :hidden :token/flags) data)]
                ($ :button
                  {:type "button"
                   :data-selected on
@@ -246,7 +246,7 @@
                      :on-change #(apply dispatch %1 idxs %&)
                      :values    (fn vs
                                   ([f] (vs f #{}))
-                                  ([f init] (into init (map f) tokens)))}]
+                                  ([f init] (into init (map f) data)))}]
           (case selected
             :label      ($ token-form-label props)
             :details    ($ token-form-details props)
@@ -265,7 +265,7 @@
            :auto-focus true
            :on-change
            (fn [event]
-             (on-change :element/update :shape/opacity (.. event -target -value)))})))
+             (on-change :object/update :shape/opacity (.. event -target -value)))})))
     ($ :fieldset.fieldset
       ($ :legend "Color")
       ($ :.context-menu-form-colors
@@ -278,7 +278,7 @@
                :checked (= value (first (values :shape/color)))
                :on-change
                (fn [event]
-                 (on-change :element/update :shape/color (.. event -target -value)))})))))))
+                 (on-change :object/update :shape/color (.. event -target -value)))})))))))
 
 (defui ^:private shape-form-pattern
   [{:keys [on-change values]}]
@@ -295,14 +295,14 @@
            :on-change
            (fn [event]
              (let [value (.. event -target -value)]
-               (on-change :element/update :shape/pattern (keyword value))))})
+               (on-change :object/update :shape/pattern (keyword value))))})
         ($ :svg
           ($ :defs ($ pattern {:id id :name value}))
           ($ :rect {:x 0 :y 0 :width "100%" :height "100%" :fill (str "url(#" id ")")}))))))
 
-(defui shape-context-menu [{:keys [data]}]
+(defui ^:private context-menu-shape [{:keys [data]}]
   (let [dispatch (use-dispatch)]
-    ($ context-menu
+    ($ context-menu-fn
       {:render-toolbar
        (fn [{:keys [selected on-change]}]
          ($ :<>
@@ -322,16 +322,23 @@
        (fn []
          ($ :button
            {:type "button" :data-tooltip "Remove" :style {:margin-left "auto"}
-            :on-click #(dispatch :element/remove [(:db/id data)])}
+            :on-click #(dispatch :selection/remove)}
            ($ icon {:name "trash3-fill"})))}
       (fn [{:keys [selected]}]
         (let [props {:values
                      (fn vs
                        ([f] (vs f #{}))
-                       ([f init] (into init (map f) [data])))
+                       ([f init] (into init (map f) data)))
                      :on-change
                      (fn [event & args]
-                       (apply dispatch event [(:db/id data)] args))}]
+                       (apply dispatch event (map :db/id data) args))}]
           (case selected
             :color   ($ shape-form-color props)
             :pattern ($ shape-form-pattern props)))))))
+
+(defui context-menu [props]
+  (let [types (into #{} (map (comp keyword namespace :object/type)) (:data props))]
+    (if (= (count types) 1)
+      (case (first types)
+        :shape ($ context-menu-shape props)
+        :token ($ context-menu-token props)))))

--- a/src/main/ogres/app/component/scene_context_menu.cljs
+++ b/src/main/ogres/app/component/scene_context_menu.cljs
@@ -239,7 +239,7 @@
                  ($ icon {:name (if on "eye-slash-fill" "eye-fill")}))))
            ($ :button
              {:type "button" :data-tooltip "Remove"
-              :on-click #(dispatch :token/remove idxs)}
+              :on-click #(dispatch :objects/remove idxs)}
              ($ icon {:name "trash3-fill"}))))}
       (fn [{:keys [selected on-change]}]
         (let [props {:on-close  #(on-change nil)

--- a/src/main/ogres/app/component/scene_objects.cljs
+++ b/src/main/ogres/app/component/scene_objects.cljs
@@ -255,7 +255,8 @@
         tokens (sort tokens-comparator (sequence (tokens-xf type) tokens))
         entities (concat shapes tokens)
         selected (into #{} (map :db/id) selected)
-        dragging (into {} user-drag-xf conns)]
+        dragging (into {} user-drag-xf conns)
+        boundsxf (comp (filter (comp selected :db/id)) (mapcat geom/object-bounding-rect))]
     (use-drag-listener)
     ($ :g.scene-objects {}
       ($ :g.scene-objects-portal
@@ -296,7 +297,7 @@
                                :portal portal
                                :aligned-to to}))))))))))))
       ($ use-portal {:name :selected}
-        (let [[ax ay bx by] (-> (comp (filter (comp selected :db/id)) (mapcat geom/object-bounding-rect)) (sequence entities) (geom/bounding-rect))]
+        (let [[ax ay bx by] (geom/bounding-rect (sequence boundsxf entities))]
           ($ drag-local-fn {:id "selected" :disabled (some dragging selected)}
             (fn [drag]
               (let [handler (getValueByKeys drag "listeners" "onPointerDown")

--- a/src/main/ogres/app/component/scene_objects.cljs
+++ b/src/main/ogres/app/component/scene_objects.cljs
@@ -1,0 +1,363 @@
+(ns ogres.app.component.scene-objects
+  (:require [clojure.string :refer [join]]
+            [goog.object :refer [getValueByKeys]]
+            [ogres.app.component.scene-context-menu :refer [context-menu]]
+            [ogres.app.component.scene-pattern :refer [pattern]]
+            [ogres.app.const :refer [grid-size]]
+            [ogres.app.geom :as geom]
+            [ogres.app.hooks :refer [use-subscribe use-dispatch use-portal use-query]]
+            [ogres.app.util :refer [round]]
+            [react-transition-group :refer [TransitionGroup CSSTransition]]
+            [uix.core :as uix :refer [defui $ create-ref use-callback use-effect use-state]]
+            [uix.dom :as dom]
+            ["@dnd-kit/core"
+             :refer [useDndMonitor useDraggable]
+             :rename {useDndMonitor use-dnd-monitor
+                      useDraggable use-draggable}]))
+
+(defn ^:private stop-propagation
+  "Defines an event handler that ceases event propagation."
+  [event]
+  (.stopPropagation event))
+
+(defn ^:private shapes-comparator
+  "Defines a comparator function for shapes."
+  [a b]
+  (let [{[ax ay] :object/point} a
+        {[bx by] :object/point} b]
+    (compare [ax ay] [bx by])))
+
+(defn ^:private tokens-comparator
+  "Defines a comparator function for tokens."
+  [a b]
+  (let [{size-a :token/size [ax ay] :object/point} a
+        {size-b :token/size [bx by] :object/point} b]
+    (compare [size-b ax ay] [size-a bx by])))
+
+(def ^{:private true
+       :doc "Defines a transducer which expects a collection of user
+             entities, returning a sequence of key-value pairs whose
+             keys are the IDs of the objects currently being dragged
+             and whose values are the user that is dragging that object."}
+  user-drag-xf
+  (comp (filter (comp seq :user/dragging))
+        (mapcat (fn [user]
+                  (map (juxt :db/id (constantly user))
+                       (:user/dragging user))))))
+
+(defn ^:private alignment-xf
+  "Returns a transducer which expects a collection of points in the
+   form of [Ax Ay Bx By ...] and aligns those points to the nearest
+   grid intersection given a drag delta (dx dy) and the current
+   grid offset given as (ox oy)."
+  [dx dy ox oy]
+  (comp (partition-all 2)
+        (mapcat
+         (fn [[x y]]
+           [(+ (round (- (+ x dx) ox) grid-size) ox)
+            (+ (round (- (+ y dy) oy) grid-size) oy)]))))
+
+(defn ^:private tokens-xf
+  "Defines a transducer which expects a collection of token entities
+   and returns only the elements suitable for rendering given the
+   user type."
+  [user]
+  (filter
+   (fn [token]
+     (or (= user :host)
+         (not (contains? (:token/flags token) :hidden))))))
+
+(defn ^:private use-cursor-point
+  "Defines a React state hook which returns a point [Ax Ay] of the
+   given user's current cursor position, if available."
+  [uuid ox oy]
+  (let [[point set-point] (use-state nil)]
+    (use-effect
+     (fn []
+       (if (nil? uuid)
+         (set-point nil))) [uuid])
+    (use-subscribe :cursor/moved {:disabled (nil? uuid)}
+      (use-callback
+       (fn [{[id cx cy] :args}]
+         (if (= id uuid)
+           (set-point
+            (fn [[_ _ dx dy]]
+              (let [rx (- cx ox) ry (- cy oy)]
+                (if (nil? dx)
+                  [(- rx rx) (- ry ry) rx ry]
+                  [(- cx ox dx) (- cy oy dy) dx dy])))))) [uuid ox oy])) point))
+
+(defui ^:private drag-remote-fn
+  "Renders the given children as a function with the user's current
+   cursor position as its only argument in the form of [Ax Ay]."
+  [{:keys [children user x y]}]
+  (let [point (use-cursor-point user x y)]
+    (children point)))
+
+(defui ^:private drag-local-fn
+  "Renders the given children as a function with an object of drag
+   parameters passed as its only argument.
+   https://docs.dndkit.com/api-documentation/draggable/usedraggable"
+  [{:keys [children id disabled]
+    :or   {disabled false}}]
+  (let [options (use-draggable #js {"id" id "disabled" (boolean disabled)})]
+    (children options)))
+
+(defui ^:private shape-circle
+  [{:keys [data]}]
+  (let [{[ax ay] :shape/points} data]
+    ($ :circle
+      {:cx 0 :cy 0 :r (geom/chebyshev-distance 0 0 ax ay)})))
+
+(defui ^:private shape-rect
+  [{:keys [data]}]
+  (let [{[ax ay] :shape/points} data]
+    ($ :path
+      {:d (join " " [\M 0 0 \H ax \V ay \H 0 \Z])})))
+
+(defui ^:private shape-line
+  [{:keys [data]}]
+  (let [{[ax ay] :shape/points} data]
+    ($ :line
+      {:x1 0 :y1 0 :x2 ax :y2 ay :stroke-width 16 :stroke-linecap "round"})))
+
+(defui ^:private shape-cone
+  [{:keys [data]}]
+  (let [{[bx by] :shape/points} data]
+    ($ :polygon
+      {:points (join " " (geom/cone-points 0 0 bx by))})))
+
+(defui ^:private shape-poly
+  [{:keys [data]}]
+  (let [{points :shape/points} data]
+    ($ :polygon
+      {:points (join " " (into [0 0] points))})))
+
+(defui ^:private shape [props]
+  (case (keyword (name (:object/type (:data props))))
+    :circle ($ shape-circle props)
+    :rect   ($ shape-rect props)
+    :line   ($ shape-line props)
+    :cone   ($ shape-cone props)
+    :poly   ($ shape-poly props)))
+
+(defui ^:private object-shape [{:keys [entity]}]
+  (let [{id :db/id
+         color :shape/color
+         pattern-name :shape/pattern
+         opacity :shape/opacity
+         [ax ay] :object/point} entity
+        [bx by cx cy] (geom/object-bounding-rect entity)]
+    ($ :g.scene-shape
+      ($ :defs.scene-shape-defs
+        ($ pattern
+          {:id (str "shape-pattern-" id)
+           :name pattern-name
+           :color color}))
+      ($ :rect.scene-shape-bounds
+        {:x (- bx ax 6)
+         :y (- by ay 6)
+         :rx 3
+         :ry 3
+         :width (+ (- cx bx) (* 6 2))
+         :height (+ (- cy by) (* 6 2))})
+      ($ :g.scene-shape-path {:stroke color :fill (str "url(#shape-pattern-" id ")") :fill-opacity opacity}
+        ($ shape {:data entity})))))
+
+(defui ^:private object-token [props]
+  (let [{id :db/id} (:entity props)]
+    ($ :<>
+      ($ :use {:href (str "#token" id)})
+      (if-let [[ax ay bx by] (:aligned-to props)]
+        (if-let [portal (deref (:portal props))]
+          (dom/create-portal
+           ($ :g.scene-object-align
+             ($ :rect
+               {:x  ax :y (+ ay 1)
+                :rx 3  :ry 3
+                :width (- bx ax 1)
+                :height (- by ay 1)})) portal))))))
+
+(defui ^:private object [props]
+  (case (keyword (namespace (:object/type (:entity props))))
+    :shape ($ object-shape props)
+    :token ($ object-token props)))
+
+(defn ^:private use-drag-listener []
+  (let [dispatch (use-dispatch)]
+    (use-dnd-monitor
+     #js {"onDragStart"
+          (use-callback
+           (fn [data]
+             (let [id (.. data -active -id)]
+               (if (= id "selected")
+                 (dispatch :drag/start-selected)
+                 (dispatch :drag/start id)))) [dispatch])
+          "onDragCancel"
+          (use-callback
+           (fn []
+             (dispatch :drag/end)) [dispatch])
+          "onDragEnd"
+          (use-callback
+           (fn [data]
+             (let [event (.-activatorEvent data)
+                   id (.. data -active -id)
+                   dx (.. data -delta -x)
+                   dy (.. data -delta -y)
+                   sh (.-shiftKey event)]
+               (if (and (= dx 0) (= dy 0))
+                 (if (= id "selected")
+                   (let [id (.. event -target (closest "[data-id]") -dataset -id)]
+                     (dispatch :objects/select (js/Number id) sh))
+                   (dispatch :objects/select id sh))
+                 (if (= id "selected")
+                   (dispatch :objects/translate-selected dx dy)
+                   (dispatch :objects/translate id dx dy))))) [dispatch])})))
+
+(def ^:private query
+  [{:root/user
+    [:user/type
+     [:bounds/self :default [0 0 0 0]]
+     {:user/camera
+      [:db/id
+       :camera/selected
+       [:camera/scale :default 1]
+       [:camera/point :default [0 0]]
+       {:camera/scene
+        [[:scene/grid-origin :default [0 0]]
+         [:scene/grid-align :default false]
+         {:scene/tokens
+          [:db/id
+           [:object/type :default :token/token]
+           [:object/point :default [0 0]]
+           [:token/flags :default #{}]
+           [:token/label :default ""]
+           [:token/size :default 5]
+           [:token/light :default 15]
+           [:aura/radius :default 0]
+           {:token/image [:image/checksum]}
+           {:scene/_initiative [:db/id :initiative/turn]}]}
+         {:scene/shapes
+          [:db/id
+           [:object/type :default :shape/circle]
+           [:object/point :default [0 0]]
+           [:shape/points :default [0 0]]
+           [:shape/color :default "#f44336"]
+           [:shape/opacity :default 0.25]
+           [:shape/pattern :default :solid]]}]}]}]
+    :root/session
+    [{:session/conns
+      [:user/uuid :user/color :user/dragging]}]}])
+
+(defui objects []
+  (let [result (use-query query [:db/ident :root])
+        {{[_ _ bw bh] :bounds/self
+          type :user/type
+          {[cx cy]  :camera/point
+           scale    :camera/scale
+           selected :camera/selected
+           {[ox oy] :scene/grid-origin
+            align? :scene/grid-align
+            tokens :scene/tokens
+            shapes :scene/shapes}
+           :camera/scene}
+          :user/camera} :root/user
+         {conns :session/conns} :root/session} result
+        portal (uix/use-ref)
+        bounds [cx cy (+ (/ bw scale) cx) (+ (/ bh scale) cy)]
+        shapes (sort shapes-comparator shapes)
+        tokens (sort tokens-comparator (sequence (tokens-xf type) tokens))
+        entities (concat shapes tokens)
+        selected (into #{} (map :db/id) selected)
+        dragging (into {} user-drag-xf conns)]
+    (use-drag-listener)
+    ($ :g.scene-objects {}
+      ($ :g.scene-objects-portal
+        {:ref portal :tab-index -1})
+      ($ TransitionGroup {:component nil}
+        (for [entity entities
+              :let [{id :db/id [ax ay] :object/point} entity
+                    node (create-ref)
+                    user (dragging id)
+                    rect (geom/object-bounding-rect entity)
+                    seen (geom/rect-intersects-rect rect bounds)]]
+          ($ CSSTransition {:key id :nodeRef node :timeout 256}
+            ($ :g.scene-object-transition {:ref node}
+              (if (not (selected id))
+                ($ drag-remote-fn {:user (:user/uuid user) :x ax :y ay}
+                  (fn [[rx ry]]
+                    ($ drag-local-fn {:id id :disabled (some? user)}
+                      (fn [drag]
+                        (let [handler (getValueByKeys drag "listeners" "onPointerDown")
+                              dx (or (getValueByKeys drag "transform" "x") 0)
+                              dy (or (getValueByKeys drag "transform" "y") 0)
+                              tx (+ ax (or rx dx 0))
+                              ty (+ ay (or ry dy 0))
+                              to (if (and align? (.-isDragging drag) (or (not= dx 0) (not= dy 0)))
+                                   (into [] (alignment-xf dx dy ox oy) rect))]
+                          ($ :g.scene-object
+                            {:ref (.-setNodeRef drag)
+                             :transform (str "translate(" tx ", " ty ")")
+                             :tab-index (if seen 0 -1)
+                             :on-pointer-down (or handler stop-propagation)
+                             :data-drag-remote (some? user)
+                             :data-drag-local (.-isDragging drag)
+                             :data-color (:user/color user)
+                             :data-id id}
+                            ($ object
+                              {:entity entity
+                               :portal portal
+                               :aligned-to to}))))))))))))
+      ($ use-portal {:name :selected}
+        (let [[ax ay bx by] (-> (comp (filter (comp selected :db/id))
+                                      (mapcat geom/object-bounding-rect))
+                                (sequence entities)
+                                (geom/bounding-rect))]
+          ($ drag-local-fn {:id "selected" :disabled (some dragging selected)}
+            (fn [drag]
+              (let [handler (getValueByKeys drag "listeners" "onPointerDown")
+                    dx (or (getValueByKeys drag "transform" "x") 0)
+                    dy (or (getValueByKeys drag "transform" "y") 0)]
+                ($ :g.scene-objects.scene-objects-selected
+                  {:ref (.-setNodeRef drag)
+                   :transform (str "translate(" dx ", " dy ")")
+                   :on-pointer-down (or handler stop-propagation)
+                   :data-drag-local (.-isDragging drag)}
+                  (if (> (count selected) 1)
+                    ($ :rect.scene-objects-bounds
+                      {:x (- ax 6) :y (- ay 6)
+                       :width  (+ (- bx ax) (* 6 2))
+                       :height (+ (- by ay) (* 6 2))
+                       :rx 3 :ry 3}))
+                  ($ TransitionGroup {:component nil}
+                    (for [entity entities
+                          :let [{id :db/id [ax ay] :object/point} entity
+                                node (create-ref)
+                                user (dragging id)
+                                rect (geom/object-bounding-rect entity)
+                                rect (if (and align? (.-isDragging drag) (or (not= dx 0) (not= dy 0)))
+                                       (into [] (alignment-xf dx dy ox oy) rect))]]
+                      ($ CSSTransition {:key id :nodeRef node :timeout 256}
+                        ($ :g.scene-object-transition {:ref node}
+                          (if (selected id)
+                            ($ drag-remote-fn {:user (:user/uuid user) :x ax :y ay}
+                              (fn [[rx ry]]
+                                ($ :g.scene-object
+                                  {:transform (str "translate(" (+ ax rx) ", " (+ ay ry) ")")
+                                   :data-drag-remote (some? user)
+                                   :data-drag-local (.-isDragging drag)
+                                   :data-color (:user/color user)
+                                   :data-id id}
+                                  ($ object
+                                    {:entity entity
+                                     :portal portal
+                                     :aligned-to rect})))))))))
+                  (let [sz 400
+                        tx (-> (+ ax bx) (* scale) (- sz) (/ 2) int)
+                        ty (-> (+ by 24) (* scale) (- 24) int)
+                        tf (str "scale(" (/ scale) ")")]
+                    ($ :foreignObject.context-menu-object
+                      {:x tx :y ty :width sz :height sz :transform tf}
+                      ($ context-menu
+                        {:data (sequence (filter (comp selected :db/id)) entities)
+                         :type type}))))))))))))

--- a/src/main/ogres/app/component/scene_pattern.cljs
+++ b/src/main/ogres/app/component/scene_pattern.cljs
@@ -12,7 +12,7 @@
     ($ :path
       {:d "M 0,20 l 20,-20 M -5,5 l 10,-10 M 15,25 l 10,-10"
        :stroke color
-       :stroke-width "1px"
+       :stroke-width 1
        :stroke-linecap "square"})))
 
 (defui ^:private pattern-circles
@@ -27,7 +27,7 @@
       {:d "M 2.5,2.5l5,5M2.5,7.5l5,-5"
        :fill "transparent"
        :stroke color
-       :stroke-width "1px"
+       :stroke-width 1
        :shape-rendering "auto"
        :stroke-linecap "square"})))
 

--- a/src/main/ogres/app/component/toolbar.cljs
+++ b/src/main/ogres/app/component/toolbar.cljs
@@ -2,7 +2,6 @@
   (:require [ogres.app.component :refer [icon]]
             [ogres.app.hooks :refer [use-dispatch use-query]]
             [ogres.app.provider.shortcut :refer [shortcuts]]
-            [ogres.app.util :refer [comp-fn]]
             [uix.core :as uix :refer [defui $ use-callback use-state]]))
 
 (def ^:private shortcut-keys
@@ -45,7 +44,7 @@
    [:user/type :default :conn]
    [:user/sharing? :default false]
    {:user/camera
-    [{:camera/selected [:scene/_tokens]}
+    [:camera/selected
      [:camera/draw-mode :default :select]
      [:camera/scale :default 1]]}])
 
@@ -58,7 +57,6 @@
          {scale    :camera/scale
           mode     :camera/draw-mode
           selected :camera/selected} :user/camera} result
-        copyable (some (comp-fn contains? identity :scene/_tokens) selected)
         on-focus (use-callback
                   (fn [event]
                     (if-let [node (.. event -target (closest "button"))]
@@ -84,9 +82,9 @@
          :on-click on-click}
         ($ action {:name "scene-select" :aria-pressed (= mode :select)}
           ($ icon {:name "cursor-fill"}))
-        ($ action {:name "copy-cut" :aria-disabled (nil? copyable)}
+        ($ action {:name "copy-cut" :aria-disabled (nil? selected)}
           ($ icon {:name "scissors"}))
-        ($ action {:name "copy-copy" :aria-disabled (nil? copyable)}
+        ($ action {:name "copy-copy" :aria-disabled (nil? selected)}
           ($ icon {:name "files"}))
         ($ action {:name "copy-paste" :aria-disabled (nil? (:user/clipboard result))}
           ($ icon {:name "clipboard2-plus"}))

--- a/src/main/ogres/app/events.cljs
+++ b/src/main/ogres/app/events.cljs
@@ -3,7 +3,7 @@
             [clojure.set :refer [union difference]]
             [clojure.string :refer [trim]]
             [ogres.app.const :refer [grid-size]]
-            [ogres.app.geom :refer [bounding-rect euclidean-distance point-within-rect]]
+            [ogres.app.geom :as geom]
             [ogres.app.util :refer [comp-fn round round-grid with-ns]]))
 
 (def ^:private suffix-max-xf
@@ -66,9 +66,6 @@
 (defn ^:private mode-allowed? [mode type]
   (not (and (contains? #{:mask :mask-toggle :mask-remove :grid} mode)
             (not= type :host))))
-
-(defn ^:private trans-xf [x y]
-  (comp (partition-all 2) (drop 1) (map (fn [[ax ay]] [(+ ax x) (+ ay y)])) cat))
 
 (defn ^:private initiative-order [a b]
   (let [f (juxt :initiative/roll :db/id)]
@@ -392,31 +389,43 @@
   [_ _ value]
   [[:db.fn/call assoc-scene :scene/lighting value]])
 
-(defmethod event-tx-fn :element/update
+;; --- Objects ---
+(defmethod event-tx-fn :objects/translate
+  ^{:doc "Translates the object given by id by the delta dx and dy."}
+  [data _ id dx dy]
+  (let [{[ax ay] :object/point} (ds/entity data id)]
+    [[:db/add id :object/point [(+ ax dx) (+ ay dy)]]]))
+
+(defmethod event-tx-fn :objects/translate-selected
+  ^{:doc "Translate the currently selected objects by the delta dx and dy."}
+  [data _ dx dy]
+  (let [select [{:user/camera [{:camera/selected [:db/id :object/point]}]}]
+        result (ds/pull data select [:db/ident :user])
+        {{selected :camera/selected} :user/camera} result]
+    (for [entity selected
+          :let [{id :db/id [ax ay] :object/point} entity]]
+      {:db/id id :object/point [(+ ax dx) (+ ay dy)]})))
+
+(defmethod event-tx-fn :objects/select
+  ^{:doc "Joins or removes the object given by id to the current selection,
+          alternating behavior based on the boolean modify."}
+  [data _ id modify]
+  (let [object (ds/entity data id)
+        entity (ds/entity data [:db/ident :user])
+        {{camera :db/id selected :camera/selected} :user/camera} entity]
+    [[:db/retract [:db/ident :user] :user/dragging]
+     (if (not modify)
+       [:db/retract camera :camera/selected])
+     (if (and modify (contains? selected object))
+       [:db/retract camera :camera/selected id]
+       {:db/id camera :camera/selected {:db/id id}})]))
+
+(defmethod event-tx-fn :object/update
   [_ _ idxs attr value]
   (for [id idxs]
     (assoc {:db/id id} attr value)))
 
-(defmethod event-tx-fn :element/select
-  ([_ event id]
-   [[:db.fn/call event-tx-fn event id false]])
-  ([data _ id shift?]
-   (let [user (ds/entity data [:db/ident :user])
-         entity (ds/entity data id)
-         camera (:db/id (:user/camera user))
-         selected (contains? (:camera/selected (:user/camera user)) entity)]
-     [[:db/retract [:db/ident :user] :user/dragging]
-      (if (not shift?)
-        [:db/retract camera :camera/selected])
-      (if (and shift? selected)
-        [:db/retract camera :camera/selected id]
-        {:db/id camera :camera/selected {:db/id id}})])))
-
-(defmethod event-tx-fn :element/remove
-  [_ _ idxs]
-  (for [id idxs]
-    [:db/retractEntity id]))
-
+;; --- Tokens ---
 (defmethod
   ^{:doc "Creates a new token on the current scene at the screen coordinates
           given by `sx` and `sy`. These coordinates are converted to the
@@ -431,10 +440,10 @@
           :camera/scene} :user/camera} user
         tx (+ (/ sx (or scale 1)) (or cx 0))
         ty (+ (/ sy (or scale 1)) (or cy 0))]
-    [(cond-> {:db/id -1}
+    [(cond-> {:db/id -1 :object/type :token/token}
        (some? checksum) (assoc :token/image {:image/checksum checksum})
-       (not align?)     (assoc :token/point [(round tx) (round ty)])
-       align?           (assoc :token/point
+       (not align?)     (assoc :object/point [(round tx) (round ty)])
+       align?           (assoc :object/point
                                [(round-grid tx (/ grid-size 2) (mod ox grid-size))
                                 (round-grid ty (/ grid-size 2) (mod oy grid-size))]))
      {:db/id (:db/id (:user/camera user))
@@ -448,33 +457,6 @@
   [_ _ idxs]
   (for [id idxs]
     [:db/retractEntity id]))
-
-(defmethod event-tx-fn :token/translate
-  [_ _ id dx dy]
-  [[:db.fn/call event-tx-fn :token/translate-all [id] dx dy]])
-
-(defmethod event-tx-fn :token/translate-all
-  [data _ idxs dx dy]
-  (let [tokens (ds/pull-many data [:db/id :token/point [:token/size :default 5]] idxs)
-        user   (ds/entity data [:db/ident :user])
-        {{{[ox oy] :scene/grid-origin align? :scene/grid-align}
-          :camera/scene} :user/camera} user]
-    (into [[:db/retract [:db/ident :user] :user/dragging]]
-          (for [{id :db/id size :token/size [tx ty] :token/point} tokens]
-            {:db/id id :token/point
-             (if align?
-               (let [rd (* (/ size 5) (/ grid-size 2))]
-                 [(round-grid (+ tx dx) rd (mod ox grid-size))
-                  (round-grid (+ ty dy) rd (mod oy grid-size))])
-               [(+ dx tx) (+ dy ty)])}))))
-
-(defmethod event-tx-fn :token/translate-selected
-  [data _ dx dy]
-  (let [user (ds/entity data [:db/ident :user])
-        idxs (map :db/id (:camera/selected (:user/camera user)))]
-    (if (seq idxs)
-      [[:db.fn/call event-tx-fn :token/translate-all idxs dx dy]]
-      [])))
 
 (defmethod event-tx-fn :token/change-flag
   [data _ idxs flag add?]
@@ -509,11 +491,14 @@
      [:db.fn/call event-tx-fn :initiative/toggle idxs false])])
 
 (defmethod event-tx-fn :shape/create
-  [_ _ kind vecs]
-  (if (> (count vecs) 2)
-    (let [[ax ay bx by] vecs]
-      (if (> (euclidean-distance ax ay bx by) 16)
-        [{:db/id -1 :shape/kind kind :shape/vecs vecs}
+  [_ _ type points]
+  (if (> (count points) 2)
+    (let [[ax ay bx by] points]
+      (if (> (geom/euclidean-distance ax ay bx by) 16)
+        [{:db/id -1
+          :object/type (keyword :shape type)
+          :object/point [ax ay]
+          :shape/points points}
          [:db.fn/call assoc-camera :camera/draw-mode :select :camera/selected -1]
          [:db.fn/call assoc-scene :scene/shapes -1]]
         []))
@@ -523,16 +508,6 @@
   [_ _ idxs]
   (for [id idxs]
     [:db/retractEntity id]))
-
-(defmethod event-tx-fn :shape/translate
-  [data _ id dx dy]
-  (let [result (ds/pull data [:shape/vecs] id)
-        {[ax ay] :shape/vecs
-         vecs    :shape/vecs} result
-        x (round (+ ax dx))
-        y (round (+ ay dy))]
-    [[:db/retract [:db/ident :user] :user/dragging]
-     {:db/id id :shape/vecs (into [x y] (trans-xf (- x ax) (- y ay)) vecs)}]))
 
 (defmethod event-tx-fn :share/initiate [] [])
 
@@ -553,20 +528,25 @@
 
 (defmethod event-tx-fn :selection/from-rect
   [data _ rect]
-  (let [root (ds/entity data [:db/ident :root])
-        user (:root/user root)
-        rect (bounding-rect rect)
-        owned (into #{} (comp (mapcat :user/dragging) (map :db/id))
-                    (:session/conns (:root/session root)))]
-    [{:db/id (:db/id (:user/camera user))
+  (let [result (ds/entity data [:db/ident :root])
+        {{{{tokens :scene/tokens
+            shapes :scene/shapes} :camera/scene
+           camera :db/id} :user/camera
+          type :user/type} :root/user
+         {conns :session/conns} :root/session} result
+        bounds (geom/bounding-rect rect)
+        restri (into #{} (comp (mapcat :user/dragging) (map :db/id)) conns)]
+    [{:db/id            camera
       :camera/draw-mode :select
       :camera/selected
-      (for [token (:scene/tokens (:camera/scene (:user/camera user)))
-            :let  [{id :db/id point :token/point flags :token/flags} token]
-            :when (and (point-within-rect point rect)
-                       (not (owned id))
-                       (or (= (:user/type user) :host)
-                           (not ((or flags #{}) :hidden))))]
+      (for [entity (concat shapes tokens)
+            :let   [{id :db/id flags :token/flags} entity]
+            :let   [[ax ay bx by] (geom/object-bounding-rect entity)]
+            :when  (and (geom/point-within-rect [ax ay] bounds)
+                        (geom/point-within-rect [bx by] bounds)
+                        (not (restri id))
+                        (or (= type :host)
+                            (not (contains? flags :hidden))))]
         {:db/id id})}]))
 
 (defmethod event-tx-fn :selection/clear
@@ -576,14 +556,9 @@
 
 (defmethod event-tx-fn :selection/remove
   [data]
-  (let [user (ds/entity data [:db/ident :user])
-        type  (->> (:camera/selected (:user/camera user))
-                   (group-by (fn [x] (cond (:scene/_tokens x) :token (:scene/_shapes x) :shape)))
-                   (first))]
-    (case (first type)
-      :token [[:db.fn/call event-tx-fn :token/remove (map :db/id (val type))]]
-      :shape [[:db.fn/call event-tx-fn :shape/remove (map :db/id (val type))]]
-      [])))
+  (let [user (ds/entity data [:db/ident :user])]
+    (for [entity (:camera/selected (:user/camera user))]
+      [:db/retractEntity (:db/id entity)])))
 
 (defmethod event-tx-fn :initiative/toggle
   [data _ idxs adding?]
@@ -846,7 +821,7 @@
   ([_ event]
    [[:db.fn/call event-tx-fn event false]])
   ([data _ cut?]
-   (let [attrs  [:db/id :token/label :token/flags :token/light :token/size :aura/radius :token/image :token/point]
+   (let [attrs  [:db/id :token/label :token/flags :token/light :token/size :aura/radius :token/image :object/point]
          select [{:user/camera [{:camera/selected (into attrs [:scene/_tokens {:token/image [:image/checksum]}])}]}]
          result (ds/pull data select [:db/ident :user])
          tokens (filter (comp-fn contains? identity :scene/_tokens) (:camera/selected (:user/camera result)))
@@ -890,13 +865,13 @@
             [gx gy] :scene/grid-origin} :camera/scene} :user/camera} :root/user
          images :root/token-images} result
         hashes (into #{} (map :image/checksum) images)
-        [ax ay bx by] (bounding-rect (mapcat :token/point clipboard))
+        [ax ay bx by] (geom/bounding-rect (mapcat :object/point clipboard))
         sx (+ (/ sw scale 2) cx)
         sy (+ (/ sh scale 2) cy)
         ox (/ (- ax bx) 2)
         oy (/ (- ay by) 2)]
     (for [[idx token] (sequence (indexed) clipboard)
-          :let [[tx ty] (:token/point token)
+          :let [[tx ty] (:object/point token)
                 cs (:image/checksum (:token/image token))
                 sz (:token/size token)
                 rd (* (/ (or sz 5) 5) (/ grid-size 2))
@@ -904,8 +879,8 @@
                 ay (+ sy ty oy (- ay))
                 tk (cond-> (merge token {:db/id idx})
                      (hashes cs)  (assoc :token/image [:image/checksum (hashes cs)])
-                     (not align?) (assoc :token/point [ax ay])
-                     align?       (assoc :token/point
+                     (not align?) (assoc :object/point [ax ay])
+                     align?       (assoc :object/point
                                          [(round-grid ax rd (mod gx grid-size))
                                           (round-grid ay rd (mod gy grid-size))]))]]
       {:db/id camera

--- a/src/main/ogres/app/events.cljs
+++ b/src/main/ogres/app/events.cljs
@@ -437,6 +437,11 @@
        [:db/retract camera :camera/selected id]
        {:db/id camera :camera/selected {:db/id id}})]))
 
+(defmethod event-tx-fn :objects/remove
+  [_ _ idxs]
+  (for [id idxs]
+    [:db/retractEntity id]))
+
 (defmethod event-tx-fn :object/update
   [_ _ idxs attr value]
   (for [id idxs]
@@ -469,11 +474,6 @@
       :camera/scene
       {:db/id (:db/id (:camera/scene (:user/camera user)))
        :scene/tokens -1}}]))
-
-(defmethod event-tx-fn :token/remove
-  [_ _ idxs]
-  (for [id idxs]
-    [:db/retractEntity id]))
 
 (defmethod event-tx-fn :token/change-flag
   [data _ idxs flag add?]
@@ -527,11 +527,6 @@
          [:db.fn/call assoc-scene :scene/shapes -1]]
         []))
     []))
-
-(defmethod event-tx-fn :shape/remove
-  [_ _ idxs]
-  (for [id idxs]
-    [:db/retractEntity id]))
 
 (defmethod event-tx-fn :share/initiate [] [])
 

--- a/src/main/ogres/app/events.cljs
+++ b/src/main/ogres/app/events.cljs
@@ -493,12 +493,19 @@
 (defmethod event-tx-fn :shape/create
   [_ _ type points]
   (if (> (count points) 2)
-    (let [[ax ay bx by] points]
+    (let [[ax ay bx by] points
+          origin [ax ay]
+          offset (fn [[ax ay]]
+                   (comp (partition-all 2)
+                         (drop 1)
+                         (mapcat
+                          (fn [[bx by]]
+                            [(- bx ax) (- by ay)]))))]
       (if (> (geom/euclidean-distance ax ay bx by) 16)
         [{:db/id -1
           :object/type (keyword :shape type)
-          :object/point [ax ay]
-          :shape/points points}
+          :object/point origin
+          :shape/points (into [] (offset origin) points)}
          [:db.fn/call assoc-camera :camera/draw-mode :select :camera/selected -1]
          [:db.fn/call assoc-scene :scene/shapes -1]]
         []))

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -55,7 +55,7 @@
   "Returns a transducer which expects a collection of points in the
    form of [Ax Ay Bx By ...] and aligns those points to the nearest
    grid intersection given a drag delta (dx dy) and the current
-   grid offset given as (ox oy)."
+   grid offset (ox oy)."
   [dx dy ox oy]
   (comp (partition-all 2)
         (mapcat

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -74,7 +74,7 @@
 ;; Tokens are defined by their position {A} and size.
 (defmethod object-bounding-rect :token/token
   [{[ax ay] :object/point size :token/size}]
-  (let [rd (/ (* size grid-size) 10)]
+  (let [rd (/ (* (or size 5) grid-size) 10)]
     [(- ax rd) (- ay rd)
      (+ ax rd) (+ ay rd)]))
 
@@ -102,10 +102,7 @@
 ;; adjacent to its neighbors.
 (defmethod object-bounding-rect :shape/poly
   [{[ax ay] :object/point points :shape/points}]
-  (let [xf (comp (partition-all 2)
-                 (mapcat
-                  (fn [[bx by]]
-                    [(+ ax bx) (+ ay by)])))]
+  (let [xf (comp (partition-all 2) (mapcat (fn [[bx by]] [(+ ax bx) (+ ay by)])))]
     (bounding-rect (into [ax ay] xf points))))
 
 ;; Lines are defined by points {A, B}, opposite ends of the segment.

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -1,5 +1,6 @@
 (ns ogres.app.geom
-  (:require [ogres.app.const :refer [grid-size]]))
+  (:require [ogres.app.const :refer [grid-size]]
+            [ogres.app.util :refer [round]]))
 
 (defn euclidean-distance
   "Returns the euclidean distance from [Ax Ay] to [Bx By]."
@@ -49,6 +50,18 @@
       (let [[x y] points]
         (recur (rest (rest points)) (min min-x x) (min min-y y) (max max-x x) (max max-y y)))
       [min-x min-y max-x max-y])))
+
+(defn alignment-xf
+  "Returns a transducer which expects a collection of points in the
+   form of [Ax Ay Bx By ...] and aligns those points to the nearest
+   grid intersection given a drag delta (dx dy) and the current
+   grid offset given as (ox oy)."
+  [dx dy ox oy]
+  (comp (partition-all 2)
+        (mapcat
+         (fn [[x y]]
+           [(+ (round (- (+ x dx) ox) grid-size) ox)
+            (+ (round (- (+ y dy) oy) grid-size) oy)]))))
 
 (defn ^:private clockwise?
   "Returns true if the given polygon has a clockwise winding order, false

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -74,33 +74,34 @@
 ;; Circles are defined by points {A, B} where A is the center and B is
 ;; some point on the circumference.
 (defmethod object-bounding-rect :shape/circle
-  [{[ax ay] :object/point [bx by cx cy] :shape/points}]
-  (let [rd (euclidean-distance bx by cx cy)]
+  [{[ax ay] :object/point [bx by] :shape/points}]
+  (let [rd (chebyshev-distance 0 0 bx by)]
     [(- ax rd) (- ay rd)
      (+ ax rd) (+ ay rd)]))
 
 ;; Cones are isosceles triangles defined by points {A, B} where A is
 ;; the apex and B is the center of the base.
 (defmethod object-bounding-rect :shape/cone
-  [{[ax ay] :object/point [bx by cx cy] :shape/points}]
-  (bounding-rect (cone-points ax ay (- cx (- bx ax)) (- cy (- by ay)))))
+  [{[ax ay] :object/point [bx by] :shape/points}]
+  (bounding-rect (cone-points ax ay (+ ax bx) (+ ay by))))
 
 ;; Rectangles are defined by points {A, B} where A and B are opposite and
 ;; opposing corners, such as top-left and bottom-right.
 (defmethod object-bounding-rect :shape/rect
-  [{[ax ay] :object/point [bx by cx cy] :shape/points}]
-  (bounding-rect [ax ay (- cx (- bx ax)) (- cy (- by ay))]))
+  [{[ax ay] :object/point [bx by] :shape/points}]
+  (bounding-rect [ax ay (+ ax bx) (+ ay by)]))
 
 ;; Polygons are defined by points {A, B, C, [...]} where each point is
 ;; adjacent to its neighbors.
 (defmethod object-bounding-rect :shape/poly
-  [{[ax ay] :object/point [bx by :as points] :shape/points}]
-  (let [dx (- bx ax)
-        dy (- by ay)
-        xf (comp (partition-all 2) (mapcat (fn [[x y]] [(- x dx) (- y dy)])))]
-    (bounding-rect (sequence xf points))))
+  [{[ax ay] :object/point points :shape/points}]
+  (let [xf (comp (partition-all 2)
+                 (mapcat
+                  (fn [[bx by]]
+                    [(+ ax bx) (+ ay by)])))]
+    (bounding-rect (into [ax ay] xf points))))
 
 ;; Lines are defined by points {A, B}, opposite ends of the segment.
 (defmethod object-bounding-rect :shape/line
-  [{[ax ay] :object/point [bx by cx cy] :shape/points}]
-  (bounding-rect [ax ay (- cx (- bx ax)) (- cy (- by ay))]))
+  [{[ax ay] :object/point [bx by] :shape/points}]
+  (bounding-rect [ax ay (+ ax bx) (+ ay by)]))

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -32,6 +32,13 @@
   [[ax ay] [bx by cx cy]]
   (and (> ax bx) (> ay by) (< ax cx) (< ay cy)))
 
+(defn rect-intersects-rect
+  "Returns true if any of the 4 corners of [Ax Ay Bx by] are within the
+   rect [Cx Cy Dx Dy]. Each rect must be given as (Min, Max)."
+  [[ax ay bx by] bounds]
+  (some (fn [point] (point-within-rect point bounds))
+        [[ax ay] [bx ay] [bx by] [ax by]]))
+
 (defn bounding-rect
   "Returns an axis-aligned minimum bounding rectangle (AABB) of the set of
    points given in the form of [Ax Ay Bx By [...]] as points [Ax Ay Bx By]

--- a/src/main/ogres/app/provider/shortcut.cljs
+++ b/src/main/ogres/app/provider/shortcut.cljs
@@ -96,9 +96,11 @@
                   (= (.-type attrs) "scene")
                   (dispatch :camera/translate (* dx 140) (* dy 140))
                   (= (.-type attrs) "token")
-                  (dispatch :token/translate (js/Number (.-id attrs)) (* dx 70) (* dy 70))
+                  (dispatch :objects/translate (js/Number (.-id attrs)) (* dx 70) (* dy 70))
+                  (= (.-type attrs) "shape")
+                  (dispatch :objects/translate (js/Number (.-id attrs)) (* dx 70) (* dy 70))
                   (= (.-activeElement js/document) (.-body js/document))
-                  (dispatch :token/translate-selected (* dx 70) (* dy 70)))))))
+                  (dispatch :objects/translate-selected (* dx 70) (* dy 70)))))))
 
     ;; Cut, copy, and paste tokens.
     (use-shortcut [\c \x \v]

--- a/src/main/ogres/app/provider/shortcut.cljs
+++ b/src/main/ogres/app/provider/shortcut.cljs
@@ -83,7 +83,7 @@
         (let [shift (.. data -originalEvent -shiftKey)
               data  (.. js/document -activeElement -dataset)]
           (if (= (.-type data) "token")
-            (dispatch :element/select (js/Number (.-id data)) shift)))))
+            (dispatch :objects/select (js/Number (.-id data)) shift)))))
 
     ;; Move tokens and pan camera around.
     (use-shortcut ["arrowleft" "arrowup" "arrowright" "arrowdown"]

--- a/src/main/ogres/app/provider/shortcut.cljs
+++ b/src/main/ogres/app/provider/shortcut.cljs
@@ -81,8 +81,9 @@
     (use-shortcut [\ ]
       (fn [data]
         (let [shift (.. data -originalEvent -shiftKey)
-              data  (.. js/document -activeElement -dataset)]
-          (if (= (.-type data) "token")
+              data  (.. js/document -activeElement -dataset)
+              type  (.-type data)]
+          (if (or (= type "shape") (= type "token"))
             (dispatch :objects/select (js/Number (.-id data)) shift)))))
 
     ;; Move tokens and pan camera around.
@@ -122,7 +123,8 @@
     (use-shortcut ["delete" "backspace"]
       (fn [data]
         (if (allowed? (.-originalEvent data))
-          (let [attrs (.. js/document -activeElement -dataset)]
-            (if (= (.-type attrs) "token")
-              (dispatch :token/remove [(js/Number (.-id attrs))])
+          (let [attr (.. js/document -activeElement -dataset)
+                type (.-type attr)]
+            (if (or (= type "shape") (= type "token"))
+              (dispatch :objects/remove [(js/Number (.-id attr))])
               (dispatch :selection/remove))))))))

--- a/web/release/ogres.app.css
+++ b/web/release/ogres.app.css
@@ -959,6 +959,10 @@ a:visited {
     stroke-width: 1px;
     stroke: var(--scene-stroke);
   }
+
+  .scene-objects-portal {
+    pointer-events: none;
+  }
 }
 
 .scene-object {
@@ -968,6 +972,11 @@ a:visited {
     border-radius: 3px;
     outline: 2px solid var(--outline-color);
   }
+}
+
+.scene-object-align {
+  fill: rgba(255, 255, 255, 0.25);
+  pointer-events: none;
 }
 
 .scene-shape {

--- a/web/release/ogres.app.css
+++ b/web/release/ogres.app.css
@@ -961,9 +961,16 @@ a:visited {
   }
 }
 
-.scene-shape {
-  shape-rendering: geometricPrecision;
+.scene-object {
+  outline: none;
 
+  &:focus-visible {
+    border-radius: 3px;
+    outline: 2px solid var(--outline-color);
+  }
+}
+
+.scene-shape {
   &:hover {
     cursor: pointer;
   }
@@ -982,65 +989,6 @@ a:visited {
     stroke-opacity: 0.8;
     stroke-width: 1px;
     stroke: var(--scene-stroke);
-  }
-}
-
-/* Scene Tokens */
-.scene-tokens {
-  .scene-token-position {
-    outline: none;
-    transition: var(--transition-drag);
-
-    &[data-hidden="true"] {
-      display: none;
-    }
-
-    &[data-drag-local="true"] {
-      transition: none;
-    }
-
-    &[data-drag-local="true"],
-    &[data-drag-remote="true"] {
-      --token-base-stroke: var(--color-session, var(--scene-stroke));
-      --token-base-stroke-width: 2px;
-    }
-
-    &:focus-visible {
-      --token-outline-width: 3px;
-    }
-  }
-
-  .scene-token-transition {
-    &.enter {
-      opacity: 0;
-      transform: translate(0, -12px);
-    }
-
-    &.enter-active {
-      opacity: 1;
-      transform: translate(0, 0);
-      transition: transform 240ms ease-in-out, opacity 240ms ease-in-out;
-    }
-
-    &.exit {
-      opacity: 1;
-      transform: translate(0, 0);
-    }
-
-    &.exit-active {
-      opacity: 0;
-      transform: translate(0, -12px);
-      transition: transform 240ms ease-in-out, opacity 240ms ease-in-out;
-    }
-  }
-
-  .scene-token-ghost > rect {
-    fill-opacity: 0.15;
-    fill: var(--scene-stroke);
-    stroke-opacity: 0.6;
-    stroke-width: 1px;
-    stroke: var(--scene-stroke);
-    transform: translate(-0.5px, 0.5px);
   }
 }
 

--- a/web/release/ogres.app.css
+++ b/web/release/ogres.app.css
@@ -708,8 +708,8 @@ a:visited {
   width: 100%;
 
   &[data-theme="light"] {
-    --scene-stroke: rgba(255, 255, 255, 1);
-    --scene-text: rgba(255, 255, 255, 1);
+    --scene-stroke: rgb(255, 255, 255);
+    --scene-text: rgb(255, 255, 255);
     --scene-text-outline: rgba(0, 0, 0, 1);
   }
 
@@ -931,21 +931,62 @@ a:visited {
   }
 }
 
-/* Scene Tokens */
-.scene-tokens {
-  &.scene-tokens-selected {
+/* Scene Objects */
+.scene-objects {
+  &.scene-objects-selected {
     --token-base-stroke: var(--color-session, var(--scene-stroke));
     --token-base-stroke-width: 1px;
 
-    .scene-token-position {
+    .scene-object-position {
       transition: none;
 
       &[data-drag-remote="true"] {
         transition: var(--transition-drag);
       }
     }
+
+    .scene-shape .scene-shape-bounds {
+      display: inherit;
+    }
   }
 
+  .scene-objects-bounds {
+    fill: transparent;
+    pointer-events: none;
+    shape-rendering: crispEdges;
+    stroke-dasharray: 3px 1px;
+    stroke-opacity: 0.6;
+    stroke-width: 1px;
+    stroke: var(--scene-stroke);
+  }
+}
+
+.scene-shape {
+  shape-rendering: geometricPrecision;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  .scene-shape-path {
+    stroke-width: 1px;
+  }
+
+  .scene-shape-bounds {
+    animation: ring-rotate 640ms linear infinite;
+    display: none;
+    fill: transparent;
+    pointer-events: none;
+    shape-rendering: crispEdges;
+    stroke-dasharray: 6px 2px;
+    stroke-opacity: 0.8;
+    stroke-width: 1px;
+    stroke: var(--scene-stroke);
+  }
+}
+
+/* Scene Tokens */
+.scene-tokens {
   .scene-token-position {
     outline: none;
     transition: var(--transition-drag);
@@ -1000,6 +1041,30 @@ a:visited {
     stroke-width: 1px;
     stroke: var(--scene-stroke);
     transform: translate(-0.5px, 0.5px);
+  }
+}
+
+.scene-object-transition {
+  &.enter {
+    opacity: 0;
+    transform: translate(0, -12px);
+  }
+
+  &.enter-active {
+    opacity: 1;
+    transform: translate(0, 0);
+    transition: transform 256ms ease-in-out, opacity 256ms ease-in-out;
+  }
+
+  &.exit {
+    opacity: 1;
+    transform: translate(0, 0);
+  }
+
+  &.exit-active {
+    opacity: 0;
+    transform: translate(0, -12px);
+    transition: transform 256ms ease-in-out, opacity 256ms ease-in-out;
   }
 }
 
@@ -1094,28 +1159,6 @@ a:visited {
   }
 }
 
-/* Scene Shapes */
-.scene-shapes {
-  .scene-shape {
-    cursor: pointer;
-
-    &:not([data-dragged-by="local"]) {
-      transition: var(--transition-drag);
-    }
-
-    &:is(:hover, [data-selected="true"], [data-dragging="true"])
-      > *:is(circle, path, line, polygon) {
-      animation: stroke-animation 1s linear infinite;
-      stroke-dasharray: 6px 2px;
-      stroke-dashoffset: 0px;
-    }
-  }
-
-  .scene-shape-rect > path {
-    shape-rendering: crispEdges;
-  }
-}
-
 .scene-drawable {
   cursor: crosshair;
 
@@ -1176,6 +1219,7 @@ a:visited {
     box-sizing: border-box;
     display: flex;
     margin: 24px 50% 24px 50%;
+    min-width: 300px;
     position: fixed;
     transform: translate(-50%, 0);
 
@@ -1228,6 +1272,7 @@ a:visited {
     }
 
     .context-menu-main {
+      flex: 1;
       pointer-events: all;
 
       &:has(:focus-visible) {
@@ -1457,16 +1502,6 @@ a:visited {
         width: 100%;
       }
     }
-  }
-}
-
-.scene-shape {
-  .context-menu-main {
-    min-width: 260px;
-  }
-
-  .context-menu-form {
-    padding-top: 12px !important;
   }
 }
 

--- a/web/release/ogres.app.css
+++ b/web/release/ogres.app.css
@@ -937,16 +937,12 @@ a:visited {
     --token-base-stroke: var(--color-session, var(--scene-stroke));
     --token-base-stroke-width: 1px;
 
-    .scene-object-position {
-      transition: none;
-
-      &[data-drag-remote="true"] {
-        transition: var(--transition-drag);
-      }
-    }
-
     .scene-shape .scene-shape-bounds {
       display: inherit;
+    }
+
+    .scene-object {
+      transition: none;
     }
   }
 
@@ -967,10 +963,24 @@ a:visited {
 
 .scene-object {
   outline: none;
+  transition: var(--transition-drag);
 
   &:focus-visible {
     border-radius: 3px;
     outline: 2px solid var(--outline-color);
+  }
+
+  &:is([data-drag-local="true"], [data-drag-remote="true"]) {
+    --token-base-stroke: var(--color-session, var(--scene-stroke));
+    --token-base-stroke-width: 2px;
+  }
+
+  &[data-drag-local="true"] {
+    transition: none;
+  }
+
+  &[data-drag-remote="true"] {
+    transition: var(--transition-drag);
   }
 }
 


### PR DESCRIPTION
This work will unify the user experience for selecting and manipulating tokens and shapes and pave the way for more types of objects to be added later.

- Merges the rendering of shapes and tokens (and all other objects) into one component.
- Draws a bounding box around all selected objects.
- New attribute `:object/type` to classify objects.
- New attribute `:object/point` which `:shape/point` and `:token/point` are now changed to.
- Changes semantics of `:shape/points` from absolute coordinate positions to relative from the `:object/point`.
- Many other smaller changes relating to the rendering of shapes and tokens.

TODO
- [x] Focus can be cycled through scene objects and are highlighted with a green outline.
- [x] Focused or selected objects can be moved with the arrow keys.
- [x] When "Align to grid" is enabled, a preview of where the token will be aligned is visible.
- [x] When "Align to grid" is enabled, tokens are aligned with the grid when moved.
- [x] When connected to an online session, object borders are highlighted with the user's color when moving them.
- [x] Copy and paste all objects, not just tokens.