### PR TITLE
Introduce scene transitions to avoid jarring changes.

### DIFF
--- a/src/main/ogres/app/component/layout.cljs
+++ b/src/main/ogres/app/component/layout.cljs
@@ -13,7 +13,7 @@
    [:panel/expanded :default true]
    [:session/status :default :none]])
 
-(defui layout []
+(defui ^:memo layout []
   (let [result (hooks/use-query query)
         {type     :user/type
          ready    :user/ready

--- a/src/main/ogres/app/component/layout.css
+++ b/src/main/ogres/app/component/layout.css
@@ -28,6 +28,13 @@
   grid-area: side;
 }
 
+.layout-scene {
+  background-color: var(--color-blues-900);
+  border: 1px solid var(--color-blues-900);
+  box-shadow: 4px 4px 0 0 rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+}
+
 .layout-toolbar {
   align-items: flex-end;
   display: flex;
@@ -66,12 +73,12 @@
         grid-template-rows: 32px 1fr 40px;
       }
 
-      .scenes-scene {
-        max-width: 100%;
+      .layout-scene {
+        border-radius: 0 0 9px 9px;
       }
 
-      .scene {
-        border-radius: 0 0 3px 3px;
+      .scenes-scene {
+        max-width: 100%;
       }
     }
 
@@ -84,12 +91,12 @@
         grid-template-rows: 1fr 40px;
       }
 
-      .scene {
-        border-radius: 3px;
+      .layout-scene {
+        border-radius: 9px;
       }
     }
 
-    .layout-scene .scene,
+    .layout-scene,
     .layout-panel .panel,
     .layout-panel .panel[data-expanded="false"] .panel-tabs {
       box-shadow: none;
@@ -160,12 +167,22 @@
       grid-template-columns: 1fr 40px;
     }
 
+    &[data-user="host"] {
+      .layout-scene {
+        border-radius: 0 9px 9px 9px;
+      }
+    }
+
     &[data-user="conn"] {
       grid-template-areas: "canvas side";
       grid-template-rows: 1fr;
 
       &[data-expanded="false"] .panel-tabs {
         grid-area: 1 / 1 / 3 / 2;
+      }
+
+      .layout-scene {
+        border-radius: 9px;
       }
     }
 

--- a/src/main/ogres/app/component/scene.cljs
+++ b/src/main/ogres/app/component/scene.cljs
@@ -577,7 +577,7 @@
         hash (-> props :data :user/camera :camera/scene :scene/image :image/hash)
         url  (hooks/use-image hash)]
     ($ CSSTransition
-      {:key id
+      {:key (str "id:" id "/" "hash:" hash)
        :nodeRef (:ref props)
        :in (or (nil? hash) (and (some? hash) (some? url)))
        :timeout 250

--- a/src/main/ogres/app/component/scene.css
+++ b/src/main/ogres/app/component/scene.css
@@ -1,8 +1,5 @@
 .scene {
   background-color: var(--color-blues-900);
-  border-radius: 0 4px 4px 4px;
-  border: 1px solid var(--color-blues-900);
-  box-shadow: 4px 4px 0 0 rgba(0, 0, 0, 0.15);
   box-sizing: border-box;
   height: 100%;
   pointer-events: all;
@@ -244,4 +241,45 @@
   stroke-width: 1px;
   stroke: var(--scene-stroke);
   opacity: 0.6;
+}
+
+.scene {
+  &.appear {
+    opacity: 0;
+  }
+
+  &.appear-active {
+    opacity: 1;
+    transition: opacity 250ms ease-in;
+  }
+
+  &.appear-done {
+    opacity: 1;
+  }
+
+  &.enter {
+    opacity: 0;
+  }
+
+  &.enter-active {
+    opacity: 1;
+    transition: opacity 250ms ease-in;
+  }
+
+  &.enter-done {
+    opacity: 1;
+  }
+
+  &.exit {
+    opacity: 1;
+  }
+
+  &.exit-active {
+    opacity: 0;
+    transition: opacity 250ms ease-in;
+  }
+
+  &.exit-done {
+    opacity: 0;
+  }
 }

--- a/src/main/ogres/app/provider/image.cljs
+++ b/src/main/ogres/app/provider/image.cljs
@@ -230,5 +230,5 @@
   [hash]
   (let [[urls on-request] (uix/use-context context)]
     (uix/use-effect
-     (fn [] (on-request hash)) [on-request hash])
+     (fn [] (when (some? hash) (on-request hash))) [on-request hash])
     (get urls hash)))


### PR DESCRIPTION
Scenes now fade in and out while loading or switching them. The most important part of this work is that the scene will not render until the scene image is fully loaded, either locally or from the host. It also helps create better transitions when switching scenes using the focus tool.
