### PR TITLE
Display outline around the affected tiles of some shapes.

### DIFF
--- a/src/main/ogres/app/component/scene_objects.cljs
+++ b/src/main/ogres/app/component/scene_objects.cljs
@@ -4,6 +4,7 @@
             [ogres.app.component :refer [icon]]
             [ogres.app.component.scene-context-menu :refer [context-menu]]
             [ogres.app.component.scene-pattern :refer [pattern]]
+            [ogres.app.const :refer [grid-size]]
             [ogres.app.geom :as geom]
             [ogres.app.hooks :as hooks]
             [react-transition-group :refer [TransitionGroup CSSTransition]]
@@ -336,7 +337,8 @@
       [:db/ident :user/uuid :user/color :user/dragging]}]}])
 
 (defui objects []
-  (let [result (hooks/use-query query [:db/ident :root])
+  (let [[_ set-ready] (uix/use-state false)
+        result (hooks/use-query query [:db/ident :root])
         {{[_ _ bw bh] :bounds/self
           type :user/type
           {[cx cy]  :camera/point
@@ -359,6 +361,11 @@
         selected (into #{} (map :db/id) selected)
         dragging (into {} user-drag-xf conns)
         boundsxf (comp (filter (comp selected :db/id)) (mapcat geom/object-bounding-rect))]
+
+    ;; automatically re-render once the portal ref is initialized.
+    (uix/use-effect
+     (fn [] (set-ready true)) [])
+
     (use-drag-listener)
     ($ :g.scene-objects {}
       ($ :g.scene-objects-portal
@@ -386,24 +393,26 @@
                               to (if (and align? (.-isDragging drag) (or (not= dx 0) (not= dy 0)))
                                    (into [] (geom/alignment-xf dx dy ox oy) rect))
                               sq (geom/object-grid-overlap entity dx dy ox oy)]
-                          ($ :<>
-                            ($ :g.scene-object-squares
-                              (for [[x y] (partition 2 sq)]
-                                ($ :rect {:key [x y] :x x :y y :width 70 :height 70})))
-                            ($ :g.scene-object
-                              {:ref (.-setNodeRef drag)
-                               :transform (str "translate(" tx ", " ty ")")
-                               :tab-index (if (and (not lock) seen) 0 -1)
-                               :on-pointer-down (or handler stop-propagation)
-                               :data-drag-remote (some? user)
-                               :data-drag-local (.-isDragging drag)
-                               :data-color (:user/color user)
-                               :data-type (namespace (:object/type entity))
-                               :data-id id}
-                              ($ object
-                                {:aligned-to to
-                                 :entity entity
-                                 :portal portal})))))))))))))
+                          ($ :g.scene-object
+                            {:ref (.-setNodeRef drag)
+                             :transform (str "translate(" tx ", " ty ")")
+                             :tab-index (if (and (not lock) seen) 0 -1)
+                             :on-pointer-down (or handler stop-propagation)
+                             :data-drag-remote (some? user)
+                             :data-drag-local (.-isDragging drag)
+                             :data-color (:user/color user)
+                             :data-type (namespace (:object/type entity))
+                             :data-id id}
+                            (if (and (seq sq) (some? (deref portal)))
+                              (dom/create-portal
+                               ($ :g.scene-object-squares
+                                 (for [[x y] (partition 2 sq)]
+                                   ($ :rect {:key [x y] :x x :y y :width grid-size :height grid-size})))
+                               (deref portal)))
+                            ($ object
+                              {:aligned-to to
+                               :entity entity
+                               :portal portal}))))))))))))
       ($ hooks/use-portal {:name :selected}
         (let [[ax ay bx by] (geom/bounding-rect (sequence boundsxf entities))]
           ($ drag-local-fn {:id "selected" :disabled (some dragging selected)}
@@ -435,16 +444,23 @@
                           (if (selected id)
                             ($ drag-remote-fn {:user (:user/uuid user) :x ax :y ay}
                               (fn [[rx ry]]
-                                ($ :g.scene-object
-                                  {:transform (str "translate(" (+ ax rx) ", " (+ ay ry) ")")
-                                   :data-drag-remote (some? user)
-                                   :data-drag-local (.-isDragging drag)
-                                   :data-color (:user/color user)
-                                   :data-id id}
-                                  ($ object
-                                    {:aligned-to rect
-                                     :entity entity
-                                     :portal portal})))))))))
+                                (let [sqrs (geom/object-grid-overlap entity dx dy ox oy)]
+                                  ($ :g.scene-object
+                                    {:transform (str "translate(" (+ ax rx) ", " (+ ay ry) ")")
+                                     :data-drag-remote (some? user)
+                                     :data-drag-local (.-isDragging drag)
+                                     :data-color (:user/color user)
+                                     :data-id id}
+                                    (if (and (seq sqrs) (some? (deref portal)))
+                                      (dom/create-portal
+                                       ($ :g.scene-object-squares
+                                         (for [[x y] (partition 2 sqrs)]
+                                           ($ :rect {:key [x y] :x x :y y :width grid-size :height grid-size})))
+                                       (deref portal)))
+                                    ($ object
+                                      {:aligned-to rect
+                                       :entity entity
+                                       :portal portal}))))))))))
                   (let [sz 400
                         tx (-> (+ ax bx) (* scale) (- sz) (/ 2) int)
                         ty (-> (+ by 24) (* scale) (- 24) int)

--- a/src/main/ogres/app/component/scene_objects.cljs
+++ b/src/main/ogres/app/component/scene_objects.cljs
@@ -4,9 +4,9 @@
             [ogres.app.component :refer [icon]]
             [ogres.app.component.scene-context-menu :refer [context-menu]]
             [ogres.app.component.scene-pattern :refer [pattern]]
-            [ogres.app.const :refer [grid-size]]
             [ogres.app.geom :as geom]
             [ogres.app.hooks :as hooks]
+            [ogres.app.svg :refer [poly->path]]
             [react-transition-group :refer [TransitionGroup CSSTransition]]
             [uix.core :as uix :refer [defui $]]
             [uix.dom :as dom]
@@ -392,7 +392,7 @@
                               ty (+ ay (or ry dy 0))
                               to (if (and align? (.-isDragging drag) (or (not= dx 0) (not= dy 0)))
                                    (into [] (geom/alignment-xf dx dy ox oy) rect))
-                              sq (geom/object-grid-overlap entity dx dy ox oy)]
+                              ts (geom/object-grid-overlap entity dx dy ox oy)]
                           ($ :g.scene-object
                             {:ref (.-setNodeRef drag)
                              :transform (str "translate(" tx ", " ty ")")
@@ -403,11 +403,10 @@
                              :data-color (:user/color user)
                              :data-type (namespace (:object/type entity))
                              :data-id id}
-                            (if (and (seq sq) (some? (deref portal)))
+                            (if (and (seq ts) (some? (deref portal)))
                               (dom/create-portal
-                               ($ :g.scene-object-squares
-                                 (for [[x y] (partition 2 sq)]
-                                   ($ :rect {:key [x y] :x x :y y :width grid-size :height grid-size})))
+                               ($ :path.scene-object-tiles
+                                 {:d (transduce (map geom/path-around-tiles) poly->path (list ts))})
                                (deref portal)))
                             ($ object
                               {:aligned-to to
@@ -444,18 +443,17 @@
                           (if (selected id)
                             ($ drag-remote-fn {:user (:user/uuid user) :x ax :y ay}
                               (fn [[rx ry]]
-                                (let [sqrs (geom/object-grid-overlap entity dx dy ox oy)]
+                                (let [tiles (geom/object-grid-overlap entity dx dy ox oy)]
                                   ($ :g.scene-object
                                     {:transform (str "translate(" (+ ax rx) ", " (+ ay ry) ")")
                                      :data-drag-remote (some? user)
                                      :data-drag-local (.-isDragging drag)
                                      :data-color (:user/color user)
                                      :data-id id}
-                                    (if (and (seq sqrs) (some? (deref portal)))
+                                    (if (and (seq tiles) (some? (deref portal)))
                                       (dom/create-portal
-                                       ($ :g.scene-object-squares
-                                         (for [[x y] (partition 2 sqrs)]
-                                           ($ :rect {:key [x y] :x x :y y :width grid-size :height grid-size})))
+                                       ($ :path.scene-object-tiles
+                                         {:d (transduce (map geom/path-around-tiles) poly->path (list tiles))})
                                        (deref portal)))
                                     ($ object
                                       {:aligned-to rect

--- a/src/main/ogres/app/component/scene_objects.cljs
+++ b/src/main/ogres/app/component/scene_objects.cljs
@@ -386,22 +386,27 @@
                               tx (+ ax (or rx dx 0))
                               ty (+ ay (or ry dy 0))
                               to (if (and align? (.-isDragging drag) (or (not= dx 0) (not= dy 0)))
-                                   (into [] (geom/alignment-xf dx dy ox oy) rect))]
-                          ($ :g.scene-object
-                            {:ref (.-setNodeRef drag)
-                             :transform (str "translate(" tx ", " ty ")")
-                             :tab-index (if (and (not lock) seen) 0 -1)
-                             :on-pointer-down (or handler stop-propagation)
-                             :data-drag-remote (some? user)
-                             :data-drag-local (.-isDragging drag)
-                             :data-color (:user/color user)
-                             :data-type (namespace (:object/type entity))
-                             :data-id id}
-                            ($ object
-                              {:aligned-to to
-                               :entity entity
-                               :portal portal
-                               :scale size}))))))))))))
+                                   (into [] (geom/alignment-xf dx dy ox oy) rect))
+                              sq (geom/object-grid-overlap entity dx dy ox oy)]
+                          ($ :<>
+                            ($ :g.scene-object-squares
+                              (for [[x y] (partition 2 sq)]
+                                ($ :rect {:key [x y] :x x :y y :width 70 :height 70})))
+                            ($ :g.scene-object
+                              {:ref (.-setNodeRef drag)
+                               :transform (str "translate(" tx ", " ty ")")
+                               :tab-index (if (and (not lock) seen) 0 -1)
+                               :on-pointer-down (or handler stop-propagation)
+                               :data-drag-remote (some? user)
+                               :data-drag-local (.-isDragging drag)
+                               :data-color (:user/color user)
+                               :data-type (namespace (:object/type entity))
+                               :data-id id}
+                              ($ object
+                                {:aligned-to to
+                                 :entity entity
+                                 :portal portal
+                                 :scale size})))))))))))))
       ($ hooks/use-portal {:name :selected}
         (let [[ax ay bx by] (geom/bounding-rect (sequence boundsxf entities))]
           ($ drag-local-fn {:id "selected" :disabled (some dragging selected)}

--- a/src/main/ogres/app/component/scene_objects.cljs
+++ b/src/main/ogres/app/component/scene_objects.cljs
@@ -299,7 +299,6 @@
        {:camera/scene
         [[:scene/grid-origin :default [0 0]]
          [:scene/grid-align :default false]
-         [:scene/grid-size :default 70]
          {:scene/tokens
           [:db/id
            [:object/type :default :token/token]
@@ -345,7 +344,6 @@
            selected :camera/selected
            {[ox oy] :scene/grid-origin
             align? :scene/grid-align
-            size   :scene/grid-size
             notes  :scene/notes
             shapes :scene/shapes
             tokens :scene/tokens}
@@ -405,8 +403,7 @@
                               ($ object
                                 {:aligned-to to
                                  :entity entity
-                                 :portal portal
-                                 :scale size})))))))))))))
+                                 :portal portal})))))))))))))
       ($ hooks/use-portal {:name :selected}
         (let [[ax ay bx by] (geom/bounding-rect (sequence boundsxf entities))]
           ($ drag-local-fn {:id "selected" :disabled (some dragging selected)}
@@ -447,8 +444,7 @@
                                   ($ object
                                     {:aligned-to rect
                                      :entity entity
-                                     :portal portal
-                                     :scale size})))))))))
+                                     :portal portal})))))))))
                   (let [sz 400
                         tx (-> (+ ax bx) (* scale) (- sz) (/ 2) int)
                         ty (-> (+ by 24) (* scale) (- 24) int)

--- a/src/main/ogres/app/component/scene_objects.css
+++ b/src/main/ogres/app/component/scene_objects.css
@@ -87,6 +87,12 @@
   stroke: var(--color-context, var(--color-red-500));
 }
 
+.scene-object-squares {
+  fill-opacity: 0.45;
+  fill: var(--color-black);
+  pointer-events: none;
+}
+
 .scene-shape:hover {
   cursor: pointer;
 }

--- a/src/main/ogres/app/component/scene_objects.css
+++ b/src/main/ogres/app/component/scene_objects.css
@@ -87,10 +87,11 @@
   stroke: var(--color-context, var(--color-red-500));
 }
 
-.scene-object-squares {
-  fill-opacity: 0.45;
-  fill: var(--color-black);
+.scene-object-tiles {
+  fill: none;
   pointer-events: none;
+  stroke-opacity: 0.8;
+  stroke: var(--scene-stroke);
 }
 
 .scene-shape:hover {

--- a/src/main/ogres/app/const.cljs
+++ b/src/main/ogres/app/const.cljs
@@ -8,3 +8,7 @@
   "The length, in pixels, of a single square in the scene grid. This
    correlates to 5 feet in this spatial system."
   70)
+
+(def ^:const half-size
+  "Half the length, in pixels, of a single square in the scene grid."
+  35)

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -35,6 +35,11 @@
        (clockwise-triangle? cx cy ax ay sx sy)
        (clockwise-triangle? bx by cx cy sx sy)))
 
+(defn rect-points
+  "Returns all points of the rect given by its top-left corner."
+  [[x y]]
+  [x y (+ x grid-size) y x (+ y grid-size) (+ x grid-size) (+ y grid-size)])
+
 (defn cone-points
   "Returns the vertices of an isosceles triangle whose altitude is equal to
    the length of the base."
@@ -215,3 +220,39 @@
                   (nth zs 4) (nth zs 5)
                   (+ px hz)  (+ py hz))]
        [px py]))))
+
+(def ^:private edge-vector
+  [[1 0 0 1] [0 1 -1 0] [-1 0 0 -1] [0 -1 1 0]])
+
+(defn ^:private edge
+  [curr ax ay bx by cx cy]
+  (cond (= cy ay) 0
+        (= cx bx) 1
+        (= cy by) 2
+        (= cx ax) 3
+        :else curr))
+
+(defn path-around-tiles
+  "Returns a closed path {Ax Ay Bx By ...} around the tiles given by their
+   top-left corner."
+  [points]
+  (let [xs (into  [] (comp (partition-all 2) (mapcat rect-points)) points)
+        vs (into #{} (partition-all 2) xs)
+        bb (bounding-rect xs)
+        ax (bb 0)
+        ay (bb 1)
+        bx (bb 2)
+        by (bb 3)
+        st (first (filter (fn [point] (= (point 1) ay)) vs))
+        sx (st 0)
+        sy (st 1)]
+    (loop [nx sx ny sy rs [] ed 0]
+      (if (and (= nx sx) (= ny sy) (seq rs)) rs
+          (let [ev (edge-vector ed)
+                cx (+ nx (* (ev 0) grid-size))
+                cy (+ ny (* (ev 1) grid-size))
+                dx (+ nx (* (ev 2) grid-size))
+                dy (+ ny (* (ev 3) grid-size))]
+            (if (contains? vs [cx cy])
+              (recur cx cy (conj rs cx cy) (edge ed ax ay bx by cx cy))
+              (recur dx dy (conj rs dx dy) (edge ed ax ay bx by dx dy))))))))

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -3,6 +3,9 @@
             [ogres.app.const :refer [grid-size half-size]]
             [ogres.app.util :refer [round]]))
 
+(def ^:const deg45->rad (/ js/Math.PI 4))
+(def ^:const deg45->sin (js/Math.sin deg45->rad))
+
 (defn euclidean-distance
   "Returns the euclidean distance from [Ax Ay] to [Bx By]."
   [ax ay bx by]
@@ -167,26 +170,40 @@
 (defmethod object-grid-overlap :shape/circle
   [object dx dy ox oy]
   (let [sz grid-size
-        hz half-size
         xs (:object/point object)
         ys (:shape/points object)
         mx (mod ox sz)
         my (mod oy sz)
-        ax (+ (nth xs 0) dx)
-        ay (+ (nth xs 1) dy)
-        bx (+ (nth ys 0) ax)
-        by (+ (nth ys 1) ay)
+        ax (+ (xs 0) dx)
+        ay (+ (xs 1) dy)
+        bx (+ (ys 0) ax)
+        by (+ (ys 1) ay)
         rd (chebyshev-distance ax ay bx by)
+        ln (* rd deg45->sin)
         cx (+ (round floor (- ax rd mx) sz) mx)
         cy (+ (round floor (- ay rd my) sz) my)
         dx (+ (round ceil  (- (+ ax rd) mx) sz) mx)
-        dy (+ (round ceil  (- (+ ay rd) my) sz) my)]
-    (into
-     [] cat
-     (for [px (range cx dx sz)
-           py (range cy dy sz)
-           :when (point-within-circle? ax ay rd (+ px hz) (+ py hz))]
-       [px py]))))
+        dy (+ (round ceil  (- (+ ay rd) my) sz) my)
+        ex (+ (round ceil  (- ax ln mx) sz) mx)
+        ey (+ (round ceil  (- ay ln my) sz) my)
+        fx (+ (round floor (- (+ ax ln) mx) sz) mx)
+        fy (+ (round floor (- (+ ay ln) my) sz) my)]
+    (loop [px cx py cy xs []]
+      (cond (> px dx) xs
+            (> py dy) (recur (+ px sz) cy xs)
+            ;; points found within the inscribed square can be omitted
+            ;; since they definitionally lie within the circle.
+            (and (= py ey) (>= px ex) (< px fx)
+                 (not (and (= ex fx) (= ey fy)))
+                 (not (and (= px ex) (= py ey)))
+                 (not (and (= px ex) (= py fy)))
+                 (not (and (= px (- fx sz)) (= py ey)))
+                 (not (and (= px (- fx sz)) (= py fy))))
+            (recur px fy xs)
+            :else
+            (if (point-within-circle? ax ay rd (+ px half-size) (+ py half-size))
+              (recur px (+ py sz) (conj xs px py))
+              (recur px (+ py sz) xs))))))
 
 (defmethod object-grid-overlap :shape/cone
   [object dx dy ox oy]

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -188,8 +188,8 @@
         ey (+ (round ceil  (- ay ln my) sz) my)
         fx (+ (round floor (- (+ ax ln) mx) sz) mx)
         fy (+ (round floor (- (+ ay ln) my) sz) my)]
-    (loop [px cx py cy rs []]
-      (cond (> px dx) rs
+    (loop [px cx py cy rs (transient [])]
+      (cond (> px dx) (persistent! rs)
             (> py dy) (recur (+ px sz) cy rs)
             ;; points found within the inscribed square can be omitted
             ;; since they definitionally lie within the circle.
@@ -201,7 +201,7 @@
                  (not (and (= px (- fx sz)) (= py fy))))
             (recur px fy rs)
             (point-within-circle? ax ay rd (+ px half-size) (+ py half-size))
-            (recur px (+ py sz) (conj rs px py))
+            (recur px (+ py sz) (conj! rs px py))
             :else
             (recur px (+ py sz) rs)))))
 
@@ -227,8 +227,8 @@
         cy (+ (round floor (- vy my) sz) my)
         dx (+ (round ceil  (- wx mx) sz) mx)
         dy (+ (round ceil  (- wy my) sz) my)]
-    (loop [px cx py cy rs []]
-      (cond (> px dx) rs
+    (loop [px cx py cy rs (transient [])]
+      (cond (> px dx) (persistent! rs)
             (> py dy)
             (recur (+ px sz) cy rs)
             (point-within-triangle?
@@ -236,7 +236,7 @@
              (zs 2) (zs 3)
              (zs 4) (zs 5)
              (+ px hz) (+ py hz))
-            (recur px (+ py sz) (conj rs px py))
+            (recur px (+ py sz) (conj! rs px py))
             :else
             (recur px (+ py sz) rs)))))
 
@@ -265,13 +265,13 @@
         st (first (filter (fn [point] (= (point 1) ay)) vs))
         sx (st 0)
         sy (st 1)]
-    (loop [nx sx ny sy rs [] ed 0]
-      (if (and (= nx sx) (= ny sy) (seq rs)) rs
+    (loop [nx sx ny sy rs (transient []) ed 0]
+      (if (and (= nx sx) (= ny sy) (> (count rs) 0)) (persistent! rs)
           (let [ev (edge-vector ed)
                 cx (+ nx (* (ev 0) grid-size))
                 cy (+ ny (* (ev 1) grid-size))
                 dx (+ nx (* (ev 2) grid-size))
                 dy (+ ny (* (ev 3) grid-size))]
             (if (contains? vs [cx cy])
-              (recur cx cy (conj rs cx cy) (edge ed ax ay bx by cx cy))
-              (recur dx dy (conj rs dx dy) (edge ed ax ay bx by dx dy))))))))
+              (recur cx cy (conj! rs cx cy) (edge ed ax ay bx by cx cy))
+              (recur dx dy (conj! rs dx dy) (edge ed ax ay bx by dx dy))))))))

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -188,9 +188,9 @@
         ey (+ (round ceil  (- ay ln my) sz) my)
         fx (+ (round floor (- (+ ax ln) mx) sz) mx)
         fy (+ (round floor (- (+ ay ln) my) sz) my)]
-    (loop [px cx py cy xs []]
-      (cond (> px dx) xs
-            (> py dy) (recur (+ px sz) cy xs)
+    (loop [px cx py cy rs []]
+      (cond (> px dx) rs
+            (> py dy) (recur (+ px sz) cy rs)
             ;; points found within the inscribed square can be omitted
             ;; since they definitionally lie within the circle.
             (and (= py ey) (>= px ex) (< px fx)
@@ -199,11 +199,11 @@
                  (not (and (= px ex) (= py fy)))
                  (not (and (= px (- fx sz)) (= py ey)))
                  (not (and (= px (- fx sz)) (= py fy))))
-            (recur px fy xs)
+            (recur px fy rs)
+            (point-within-circle? ax ay rd (+ px half-size) (+ py half-size))
+            (recur px (+ py sz) (conj rs px py))
             :else
-            (if (point-within-circle? ax ay rd (+ px half-size) (+ py half-size))
-              (recur px (+ py sz) (conj xs px py))
-              (recur px (+ py sz) xs))))))
+            (recur px (+ py sz) rs)))))
 
 (defmethod object-grid-overlap :shape/cone
   [object dx dy ox oy]
@@ -213,30 +213,32 @@
         ys (:shape/points object)
         mx (mod ox sz)
         my (mod oy sz)
-        ax (+ (nth xs 0) dx)
-        ay (+ (nth xs 1) dy)
-        bx (+ (nth ys 0) ax)
-        by (+ (nth ys 1) ay)
+        ax (+ (xs 0) dx)
+        ay (+ (xs 1) dy)
+        bx (+ (ys 0) ax)
+        by (+ (ys 1) ay)
         zs (cone-points ax ay bx by)
         vs (bounding-rect zs)
-        vx (nth vs 0)
-        vy (nth vs 1)
-        wx (nth vs 2)
-        wy (nth vs 3)
+        vx (vs 0)
+        vy (vs 1)
+        wx (vs 2)
+        wy (vs 3)
         cx (+ (round floor (- vx mx) sz) mx)
         cy (+ (round floor (- vy my) sz) my)
         dx (+ (round ceil  (- wx mx) sz) mx)
         dy (+ (round ceil  (- wy my) sz) my)]
-    (into
-     [] cat
-     (for [px (range cx dx sz)
-           py (range cy dy sz)
-           :when (point-within-triangle?
-                  (nth zs 0) (nth zs 1)
-                  (nth zs 2) (nth zs 3)
-                  (nth zs 4) (nth zs 5)
-                  (+ px hz)  (+ py hz))]
-       [px py]))))
+    (loop [px cx py cy rs []]
+      (cond (> px dx) rs
+            (> py dy)
+            (recur (+ px sz) cy rs)
+            (point-within-triangle?
+             (zs 0) (zs 1)
+             (zs 2) (zs 3)
+             (zs 4) (zs 5)
+             (+ px hz) (+ py hz))
+            (recur px (+ py sz) (conj rs px py))
+            :else
+            (recur px (+ py sz) rs)))))
 
 (def ^:private edge-vector
   [[1 0 0 1] [0 1 -1 0] [-1 0 0 -1] [0 -1 1 0]])

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -183,30 +183,6 @@
            :when (point-within-circle? ax ay rd (+ px hz) (+ py hz))]
        [px py]))))
 
-(defmethod object-grid-overlap :shape/rect
-  [object dx dy ox oy]
-  (let [sz grid-size
-        hz half-size
-        xs (:object/point object)
-        ys (:shape/points object)
-        mx (mod ox sz)
-        my (mod oy sz)
-        ax (+ (nth xs 0) dx)
-        ay (+ (nth xs 1) dy)
-        bx (+ (nth ys 0) ax)
-        by (+ (nth ys 1) ay)
-        cx (+ (round floor (- ax mx) sz) mx)
-        cy (+ (round floor (- ay my) sz) my)
-        dx (+ (round ceil  (- bx mx) sz) mx)
-        dy (+ (round ceil  (- by my) sz) my)]
-    (into
-     [] cat
-     (for [px (range cx dx sz)
-           py (range cy dy sz)
-           :let [qx (+ px hz) qy (+ py hz)]
-           :when (and (>= qx ax) (>= qy ay) (<= qx bx) (<= qy by))]
-       [px py]))))
-
 (defmethod object-grid-overlap :shape/cone
   [object dx dy ox oy]
   (let [sz grid-size
@@ -239,6 +215,3 @@
                   (nth zs 4) (nth zs 5)
                   (+ px hz)  (+ py hz))]
        [px py]))))
-
-(defmethod object-grid-overlap :shape/line [{}]
-  [])

--- a/src/main/ogres/app/geom.cljs
+++ b/src/main/ogres/app/geom.cljs
@@ -1,5 +1,6 @@
 (ns ogres.app.geom
-  (:require [ogres.app.const :refer [grid-size]]
+  (:require [clojure.math :refer [floor ceil]]
+            [ogres.app.const :refer [grid-size half-size]]
             [ogres.app.util :refer [round]]))
 
 (defn euclidean-distance
@@ -13,6 +14,27 @@
   (max (js/Math.abs (- ax bx))
        (js/Math.abs (- ay by))))
 
+(defn clockwise-triangle?
+  "Returns true if the triangle {Ax Ay Bx By Cx Cy} is in
+   clockwise winding order, false otherwise."
+  [ax ay bx by cx cy]
+  (pos? (- (* (- bx ax) (- cy ay))
+           (* (- by ay) (- cx ax)))))
+
+(defn point-within-circle?
+  "Returns true if the point {Ax Ay} is within the circle
+   {Cx Cy Radius}, false otherwise."
+  [cx cy radius ax ay]
+  (< (euclidean-distance ax ay cx cy) radius))
+
+(defn point-within-triangle?
+  "Returns true if the point {Sx Sy} is within the triangle
+   {Ax Ay Bx By Cx Cy} (in clockwise order), false otherwise."
+  [ax ay bx by cx cy sx sy]
+  (and (clockwise-triangle? ax ay bx by sx sy)
+       (clockwise-triangle? cx cy ax ay sx sy)
+       (clockwise-triangle? bx by cx cy sx sy)))
+
 (defn cone-points
   "Returns the vertices of an isosceles triangle whose altitude is equal to
    the length of the base."
@@ -22,10 +44,10 @@
         rad (js/Math.atan2 (- by ay) (- bx ax))]
     [ax
      ay
-     (+ ax (* hyp (js/Math.cos (+ rad 0.46))))
-     (+ ay (* hyp (js/Math.sin (+ rad 0.46))))
      (+ ax (* hyp (js/Math.cos (- rad 0.46))))
-     (+ ay (* hyp (js/Math.sin (- rad 0.46))))]))
+     (+ ay (* hyp (js/Math.sin (- rad 0.46))))
+     (+ ax (* hyp (js/Math.cos (+ rad 0.46))))
+     (+ ay (* hyp (js/Math.sin (+ rad 0.46))))]))
 
 (defn point-within-rect
   "Returns true if the point [Ax Ay] is within the given bounding
@@ -127,3 +149,96 @@
 (defmethod object-bounding-rect :note/note
   [{[ax ay] :object/point}]
   (bounding-rect [ax ay (+ ax 42) (+ ay 42)]))
+
+(defmulti object-grid-overlap
+  "Returns a vector of points in the form of [Ax Ay [Bx By Cx Cy ...]], each
+   point representing the top-left corner of a grid square which the given
+   object has at least some overlap with."
+  (fn [object _ _ _ _]
+    (:object/type object)))
+
+(defmethod object-grid-overlap :default [] [])
+
+(defmethod object-grid-overlap :shape/circle
+  [object dx dy ox oy]
+  (let [sz grid-size
+        hz half-size
+        xs (:object/point object)
+        ys (:shape/points object)
+        mx (mod ox sz)
+        my (mod oy sz)
+        ax (+ (nth xs 0) dx)
+        ay (+ (nth xs 1) dy)
+        bx (+ (nth ys 0) ax)
+        by (+ (nth ys 1) ay)
+        rd (chebyshev-distance ax ay bx by)
+        cx (+ (round floor (- ax rd mx) sz) mx)
+        cy (+ (round floor (- ay rd my) sz) my)
+        dx (+ (round ceil  (- (+ ax rd) mx) sz) mx)
+        dy (+ (round ceil  (- (+ ay rd) my) sz) my)]
+    (into
+     [] cat
+     (for [px (range cx dx sz)
+           py (range cy dy sz)
+           :when (point-within-circle? ax ay rd (+ px hz) (+ py hz))]
+       [px py]))))
+
+(defmethod object-grid-overlap :shape/rect
+  [object dx dy ox oy]
+  (let [sz grid-size
+        hz half-size
+        xs (:object/point object)
+        ys (:shape/points object)
+        mx (mod ox sz)
+        my (mod oy sz)
+        ax (+ (nth xs 0) dx)
+        ay (+ (nth xs 1) dy)
+        bx (+ (nth ys 0) ax)
+        by (+ (nth ys 1) ay)
+        cx (+ (round floor (- ax mx) sz) mx)
+        cy (+ (round floor (- ay my) sz) my)
+        dx (+ (round ceil  (- bx mx) sz) mx)
+        dy (+ (round ceil  (- by my) sz) my)]
+    (into
+     [] cat
+     (for [px (range cx dx sz)
+           py (range cy dy sz)
+           :let [qx (+ px hz) qy (+ py hz)]
+           :when (and (>= qx ax) (>= qy ay) (<= qx bx) (<= qy by))]
+       [px py]))))
+
+(defmethod object-grid-overlap :shape/cone
+  [object dx dy ox oy]
+  (let [sz grid-size
+        hz half-size
+        xs (:object/point object)
+        ys (:shape/points object)
+        mx (mod ox sz)
+        my (mod oy sz)
+        ax (+ (nth xs 0) dx)
+        ay (+ (nth xs 1) dy)
+        bx (+ (nth ys 0) ax)
+        by (+ (nth ys 1) ay)
+        zs (cone-points ax ay bx by)
+        vs (bounding-rect zs)
+        vx (nth vs 0)
+        vy (nth vs 1)
+        wx (nth vs 2)
+        wy (nth vs 3)
+        cx (+ (round floor (- vx mx) sz) mx)
+        cy (+ (round floor (- vy my) sz) my)
+        dx (+ (round ceil  (- wx mx) sz) mx)
+        dy (+ (round ceil  (- wy my) sz) my)]
+    (into
+     [] cat
+     (for [px (range cx dx sz)
+           py (range cy dy sz)
+           :when (point-within-triangle?
+                  (nth zs 0) (nth zs 1)
+                  (nth zs 2) (nth zs 3)
+                  (nth zs 4) (nth zs 5)
+                  (+ px hz)  (+ py hz))]
+       [px py]))))
+
+(defmethod object-grid-overlap :shape/line [{}]
+  [])

--- a/src/main/ogres/app/util.cljs
+++ b/src/main/ogres/app/util.cljs
@@ -15,9 +15,10 @@
            (map first (f second pcoll))))))
 
 (defn round
-  "Round the scalar `x` to nearest `n` (default 1)."
-  ([x]   (round x 1))
-  ([x n] (* (js/Math.round (/ x n)) n)))
+  "Round x to the nearest integer."
+  ([x]     (js/Math.round x))
+  ([x n]   (* (js/Math.round (/ x n)) n))
+  ([f x n] (* (f (/ x n)) n)))
 
 (defn display-size
   "Returns the given size in bytes as a string using the most appropriate


### PR DESCRIPTION
Draw an outline around tiles that are affected by circles and cones to help reduce the ambiguity about which tiles are affected by, for example, a spell.

Example (WIP)
![Screenshot 2025-04-04 at 9 43 06 PM](https://github.com/user-attachments/assets/de326ed6-04db-447d-9428-d43e1f384075)

TODO
- [ ] Display outlines while drawing new shapes.
- [ ] Provide option to toggle these outlines on or off.
- [ ] Improve outlines for cones.