### PR TITLE
Fixes #186

### DIFF
--- a/src/main/ogres/server/core.clj
+++ b/src/main/ogres/server/core.clj
@@ -213,14 +213,16 @@
          {"/ws" actions}
          {:listener-fn create-listener}))}})))
 
-(defn create-dev-server []
-  (-> (create-server)
-      (merge {:env :dev ::server/join? false})
-      (server/dev-interceptors)
-      (server/create-server)))
+(defn create-dev-server
+  ([] (create-dev-server {}))
+  ([opts] ; Modified to accept opts
+   (-> (create-server opts) ; Modified to pass opts
+       (merge {:env :dev ::server/join? false})
+       (server/dev-interceptors)
+       (server/create-server))))
 
-(defn ^:export run-development [& _args]
-  (let [server (create-dev-server)]
+(defn ^:export run-development [args-map] ; Modified to use args-map
+  (let [server (create-dev-server args-map)] ; Modified to pass args-map
     (println "Starting the development server on port" (::server/port server))
     (server/start server)))
 


### PR DESCRIPTION
This PR modifies the development server (`core.clj`) to accept a port configuration option, allowing users to specify which port the server should run on.  The dev server can be run with the argument ':port [#]' to set a port manually, but will use the default of 5000 if no argument is provided.

Feel free to remove the comments.  I noticed you don't have a lot, force of habit for me.