### PR TITLE
Update Docker Builds and Configurations

### DIFF
--- a/deploy/docker-nginx.template
+++ b/deploy/docker-nginx.template
@@ -13,19 +13,16 @@ server {
         try_files $uri $uri/index.html =404;
     }
 
-    # Release build
-    location /play/release/${VERSION} {
+    # Local release builds
+    location /release/ {
         alias /usr/share/nginx/app/web/release/;
+        try_files $uri $uri/ @fallback;
     }
 
-    # Release build (for watch-mode development?)
-    location /release/${VERSION} {
-        alias /usr/share/nginx/app/web/release/;
-    }
-
-    # Past release bundles supplied from Github Pages
-    location /release {
+    # Fallback to release bundles supplied from Github Pages
+    location @fallback {
         root /usr/share/nginx/html;
+        try_files $uri $uri/ =404;
     }
 
     # Backend

--- a/deploy/frontend.dockerfile
+++ b/deploy/frontend.dockerfile
@@ -21,14 +21,16 @@ RUN npx esbuild \
 FROM clojure:temurin-21-tools-deps-bookworm AS frontend-release
 ARG VERSION
 ARG SERVER_SOCKET_URL="wss://ogres.app/ws"
-ENV VERSION=${VERSION:-"latest"} \
+ENV VERSION=${VERSION:-"dev"} \
   OUTPUT_DIR="web/release/${VERSION}" \
   ASSET_PATH="release/${VERSION}"
 WORKDIR /build
 COPY . .
-COPY --from=node /node/web/release ./web/release/${VERSION}
+COPY --from=node /node/node_modules ./node_modules/
+COPY --from=node /node/web/release/icons.svg /node/web/release/ogres* ./web/release/${VERSION}/
 RUN clojure -M -m shadow.cljs.devtools.cli release app \
   --config-merge "{:closure-defines {ogres.app.const/VERSION \"${VERSION}\" ogres.app.const/PATH \"/release/${VERSION}\" ogres.app.const/SOCKET-URL \"${SERVER_SOCKET_URL}\"}}"
+
 VOLUME ["/build"]
 
 # Watch build stage (for development)
@@ -40,8 +42,8 @@ ARG SERVER_SOCKET_URL
 ENV SERVER_SOCKET_URL=${SERVER_SOCKET_URL:-"wss://ogres.app/ws"}
 WORKDIR /build
 COPY . .
-COPY --from=node /node/node_modules ./node_modules
-COPY --from=node /node/web/release ./web/release
+COPY --from=node /node/node_modules ./node_modules/
+COPY --from=node /node/web/release ./web/release/
 EXPOSE 9630
 CMD clojure -M -m shadow.cljs.devtools.cli watch app --config-merge "{:closure-defines {ogres.app.const/SOCKET-URL \"${SERVER_SOCKET_URL}\"}}"
 VOLUME ["/build"]

--- a/deploy/frontend.dockerfile
+++ b/deploy/frontend.dockerfile
@@ -3,28 +3,48 @@ ARG MODE="release"
 FROM node:alpine AS node
 RUN mkdir -p /node
 WORKDIR /node
-COPY package.json package-lock.json /node/
-RUN npm install --legacy-peer-deps
+COPY package.json package-lock.json ./
+RUN npm ci
+RUN mkdir -p web/release
+COPY . .
+RUN npm rebuild esbuild
+RUN npx esbuild \
+  --bundle \
+  --minify \
+  --loader:.svg=dataurl \
+  --outfile=./web/release/ogres.app.css \
+  ./src/main/ogres/app/resource/root.css
 
+# Release build stage
+# - Compiles the ClojureScript frontend to `/release/$VERSION` directory, defaulting to `/release/latest`
+# - Copies `/release` assets such `icons.svg` and the ESBuild output of `ogres.app.css` to the same directory
 FROM clojure:temurin-21-tools-deps-bookworm AS frontend-release
-ARG VERSION="dev"
-ARG SERVER_SOCKET_URL="wss://ogres.app/ws"
-VOLUME /build
-WORKDIR /build
-COPY --from=node /node/node_modules /build/node_modules
-COPY ./ /build
-RUN clojure -M -m shadow.cljs.devtools.cli release app --config-merge "{:closure-defines {ogres.app.const/VERSION \"${VERSION}\" ogres.app.const/PATH \"/release/${VERSION}\" ogres.app.const/SOCKET-URL \"${SERVER_SOCKET_URL}\"}}"
-
-FROM clojure:temurin-21-tools-deps-bookworm AS frontend-watch
 ARG VERSION
-ENV VERSION=${VERSION:-"dev"}
+ARG SERVER_SOCKET_URL="wss://ogres.app/ws"
+ENV VERSION=${VERSION:-"latest"} \
+  OUTPUT_DIR="web/release/${VERSION}" \
+  ASSET_PATH="release/${VERSION}"
+WORKDIR /build
+COPY . .
+COPY --from=node /node/web/release ./web/release/${VERSION}
+RUN clojure -M -m shadow.cljs.devtools.cli release app \
+  --config-merge "{:closure-defines {ogres.app.const/VERSION \"${VERSION}\" ogres.app.const/PATH \"/release/${VERSION}\" ogres.app.const/SOCKET-URL \"${SERVER_SOCKET_URL}\"}}"
+VOLUME ["/build"]
+
+# Watch build stage (for development)
+# - Compiles the ClojureScript frontend to the `/release` directory
+# - Watches for changes in the source code and rebuilds automatically
+# - Does not watch for CSS changes, only ClojureScript changes
+FROM clojure:temurin-21-tools-deps-bookworm AS frontend-watch
 ARG SERVER_SOCKET_URL
 ENV SERVER_SOCKET_URL=${SERVER_SOCKET_URL:-"wss://ogres.app/ws"}
-VOLUME /build
 WORKDIR /build
-COPY --from=node /node/node_modules /build/node_modules
-COPY ./ /build
+COPY . .
+COPY --from=node /node/node_modules ./node_modules
+COPY --from=node /node/web/release ./web/release
 EXPOSE 9630
-CMD clojure -M -m shadow.cljs.devtools.cli watch app --config-merge "{:closure-defines {ogres.app.const/VERSION \"${VERSION}\" ogres.app.const/PATH \"/release/${VERSION}\" ogres.app.const/SOCKET-URL \"${SERVER_SOCKET_URL}\"}}"
+CMD clojure -M -m shadow.cljs.devtools.cli watch app --config-merge "{:closure-defines {ogres.app.const/SOCKET-URL \"${SERVER_SOCKET_URL}\"}}"
+VOLUME ["/build"]
 
+# The ARG MODE determines which build stage to use
 FROM frontend-${MODE}

--- a/deploy/nginx.dockerfile
+++ b/deploy/nginx.dockerfile
@@ -9,3 +9,4 @@ ENV SERVER_SOCKET_URL=${SERVER_SOCKET_URL:-"http://backend:8090/ws"}
 ARG VERSION
 ENV VERSION=${VERSION}
 COPY --from=website /website /usr/share/nginx/html
+RUN if [ -n "$VERSION" ]; then echo "$VERSION" >> /usr/share/nginx/html/releases.txt; fi

--- a/deploy/nginx.dockerfile
+++ b/deploy/nginx.dockerfile
@@ -7,5 +7,5 @@ FROM nginx:alpine
 ARG SERVER_SOCKET_URL
 ENV SERVER_SOCKET_URL=${SERVER_SOCKET_URL:-"http://backend:8090/ws"}
 ARG VERSION
-ENV VERSION=${VERSION:-"dev"}
+ENV VERSION=${VERSION}
 COPY --from=website /website /usr/share/nginx/html

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,13 +4,14 @@ services:
       context: .
       dockerfile: ./deploy/frontend.dockerfile
       args:
-        # The release tag for the client build (by default the client uses `latest`).
-        # - For a different build, supply the following param: `/play?r={VERSION}`.
-        VERSION: "dev"
         # Mode must be either "release" (for production) or "watch" (for development)
         MODE: "release"
+        # The release tag for the client build (which can be accessed via `/play?r=VERSION`)
+        # - Note: Only applicable for MODE `release`.
+        VERSION: "dev"
         # The URL that will be accessed by the user's browser
-        # - When running in production, you likely want to use `wss://{YOUR_DOMAIN}/ws`
+        # - When run in production, you will likely want to use `wss://{YOUR_DOMAIN}/ws`,
+        #   with the Nginx container behind a SSL-terminated reverse proxy.
         SERVER_SOCKET_URL: "ws://0.0.0.0:8080/ws"
     volumes:
       - frontend:/build
@@ -30,20 +31,22 @@ services:
       context: .
       dockerfile: ./deploy/backend.dockerfile
     expose:
-    # The websocket connection exposed by the server
-    - "8090"
+      # The websocket connection exposed by the server
+      - "8090"
 
   nginx:
     build:
       context: .
       dockerfile: ./deploy/nginx.dockerfile
       args:
-        VERSION: "dev"
+        # When specified, the VERSION argument will be appended to `releases.txt`
+        # - NOTE: This will prompt the client that an upgrade is available to VERSION.
+        # VERSION: "dev"
         # The URL to the server's websocket, which will be proxied by nginx
         SERVER_SOCKET_URL: "http://backend:8090/ws"
     volumes:
-        - ./deploy/docker-nginx.template:/etc/nginx/templates/default.conf.template:ro
-        - frontend:/usr/share/nginx/app
+      - ./deploy/docker-nginx.template:/etc/nginx/templates/default.conf.template:ro
+      - frontend:/usr/share/nginx/app
     ports:
       - "8080:80"
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -2,8 +2,8 @@
  :dev-http {8080 ["web" "site/web"]}
  :builds   {:app {:target           :esm
                   :compiler-options {:infer-externs :auto :externs ["datascript/externs.js"]}
-                  :output-dir       "web/release"
-                  :asset-path       "release"
+                  :output-dir       #shadow/env ["OUTPUT_DIR" :default "web/release"]
+                  :asset-path       #shadow/env ["ASSET_PATH" :default "release"]
                   :devtools         {:preloads [ogres.app.preload]}
                   :modules          {:ogres.app {:entries [ogres.app.core] :init-fn ogres.app.core/main}}}
             :test {:target    :node-test


### PR DESCRIPTION
This pull request attempts to fix several issues with the Dockerfile instructions and tries to more accurately represent the existing release and development pipelines.

The intended effects of these changes are:

- Frontend `release` builds will output assets to `/build/web/release/${VERSION}` (with `VERSION` defaulting to `dev`). When run, the container will launch into a Clojure repl and exit as the build will have been completed at that stage.
- Frontend `watch` builds will output changes to `/build/web/release`. When run via `docker compose watch`, the container will continously poll for ClojureScript changes.
- The `ogres.app.css` stylesheet will be built from source via `esbuild` and used in place of the latest version checked in to the repository. Watch polling will not cover stylesheet changes.
- The Nginx configuration will attempt to load `/release` directories in the following order: 
  - First, by searching the output of the `/build/web/release` frontend volume which is mounted to `/usr/share/nginx/app/web/release/`; 
  - Second, by searching the output of the `gh-pages` clone which is mounted to `/usr/share/nginx/html`.
- This Nginx configuration means that when `/play` is accessed without an `?r=${VERSION}` parameter, it will attempt to load assets from `/release/latest` which will be provided by the `gh-pages` clone. 
  - Would we want `/release/latest` to link to `/build/web/release/${VERSION}` instead? I decided to leave the default as the latest official release for now.
- When a `VERSION` argument is supplied to the Nginx build, it will append `VERSION` to `releases.txt`, thereby prompting the user that an upgrade is available. This argument will be commented out in the `docker-compose.yaml` configuration. 
- Users will now be able to use `http://localhost:8080/play` when running `docker compose watch` instead of bypassing the `localhost` initialization check in `web/index.html`. Previously, users were required to use `127.0.0.1` or `0.0.0.0` to load the watch build alongside a `?r=${VERSION}` parameter. 
  - However, this means users *will* need to use `127.0.0.1` or `0.0.0.0` when accessing any `release` builds locally.

The `localhost` versus `127.0.0.1` and `0.0.0.0` aspect is not ideal, though I'm not sure how to better handle initialization at this point. Also, when jumping between modes, users should re-create the `frontend` volume. Despite these limitations, hopefully the changes are a step in the right direction. 

Any feedback on these points or clarity on how these images are being used in the community would be appreciated. I've tried to accommodate both the developer and self-hosted use cases. 

Resolves #184.